### PR TITLE
Feature/updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+spec/dummy/
 .ruby-version
 .env*

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/log/
 spec/dummy/
 .ruby-version
 .env*

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 .ruby-version
+.env*

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
---format documentation
 --color

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ship_quiet_logistics.gemspec
 gemspec
-
-gem 'pry', '~> 0.10.3'

--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ Or install it yourself as:
 
     $ gem install ship_quiet_logistics
 
+## Configuration
+
+WIP: Quiet Logistics uses S3 buckets and SQS queues for it's operations. Some ENV variables will need to be set.
+
+```ruby
+ENV['AWS_ACCESS_KEY_ID']
+ENV['AWS_SECRET_ACCESS_KEY']
+ENV['QUIET_INCOMING_QUEUE']
+ENV['QUIET_INCOMING_BUCKET']
+ENV['QUIET_OUTGOING_QUEUE']
+ENV['QUIET_OUTGOING_BUCKET']
+```
+
 ## Usage
 
 TODO: Write usage instructions here

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ ENV['QUIET_OUTGOING_QUEUE']
 ENV['QUIET_OUTGOING_BUCKET']
 ```
 
+Additionnaly Quiet Logistics requires a Business Unit and a Client ID
+
 ## Usage
 
 TODO: Write usage instructions here

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Or install it yourself as:
 
     $ gem install ship_quiet_logistics
 
-Run the intall generator
+Run the install generator
 
     $ bundle exec rails g ship_quiet_logistics:install
 
-Run it's migration
+Run its migration
 
     $ bundle exec rake db:migrate
 

--- a/README.md
+++ b/README.md
@@ -20,18 +20,50 @@ Or install it yourself as:
 
     $ gem install ship_quiet_logistics
 
+Run the intall generator
+
+    $ bundle exec rails g ship_quiet_logistics:install
+
+Run it's migration
+
+    $ bundle exec rake db:migrate
+
 ## Configuration
 
-WIP: Quiet Logistics uses S3 buckets and SQS queues for it's operations. Some ENV variables will need to be set.
+#### Required ENV Vars
+
+    ENV['QUIET_AWS_ACCESS_KEY'] and ENV['QUIET_AWS_SECRET_KEY']
+
+#### Required Configuration Settings
 
 ```ruby
-ENV['AWS_ACCESS_KEY_ID']
-ENV['AWS_SECRET_ACCESS_KEY']
-ENV['QUIET_INCOMING_QUEUE']
-ENV['QUIET_INCOMING_BUCKET']
-ENV['QUIET_OUTGOING_QUEUE']
-ENV['QUIET_OUTGOING_BUCKET']
+ShipQuietLogistics.configure do |config|
+  config.outgoing_bucket  = ENV['QUIET_OUTGOING_BUCKET']
+  config.outgoing_queue   = ENV['QUIET_OUTGOING_QUEUE']
+  config.incoming_bucket  = ENV['QUIET_INCOMING_BUCKET']
+  config.incoming_queue   = ENV['QUIET_INCOMING_QUEUE']
+  config.inventory_queue  = ENV['QUIET_INVENTORY_QUEUE']
+  config.business_unit    = ENV['QUIET_BUSINESS_UNIT']
+  config.client_id        = ENV['QUIET_CLIENT_ID']
+end
 ```
+
+#### Optional Configuration Settings
+
+```ruby
+ShipQuietLogistics.configure do |config|
+  config.error_message_handler = # anything that responds to `.call`
+  config.process_shipment_handler = # anything that responds to `.call`
+end
+```
+
+##### The Error Message Handler
+
+Any object that responds to `.call` can be set for error message handler to know more about it please check the implementation under `handlers/error_response_handler`.
+
+##### The Process Shipment Handler
+
+Any object that responds to `.call` can be set for process shipment handler to know more about it please check the implementation under `handlers/process_shipment_handler`.
 
 Additionnaly Quiet Logistics requires a Business Unit and a Client ID
 
@@ -44,6 +76,16 @@ TODO: Write usage instructions here
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Testing
+
+This project uses RSpec and you can run the tests either by:
+
+    $ bundle exec rake
+
+Or if the dummy app is already installed
+
+    $ bundle exec rspec spec
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Additionnaly Quiet Logistics requires a Business Unit and a Client ID
 
 ## Usage
 
-TODO: Write usage instructions here
+To encourage decoupling from what a Spree/Solidus shipment type is, it's a good idea to decorate the shipment we have into the shipment surface API this plugin expects. For guidance on this subject matter please look at the `spec/support/shipment_decorator` for a working decorator. More information on what methods are called on `shipment` can also be found by reading `lib/ship_quiet_logistics/documents/shipment_order`. Reading source code is fun!
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,19 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+require 'spree/testing_support/extension_rake'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task :default do
+  if Dir['spec/dummy'].empty?
+    Rake::Task[:test_app].invoke
+    Dir.chdir('../../')
+  end
+  Rake::Task[:spec].invoke
+end
+
+desc 'Generates a dummy app for testing'
+task :test_app do
+  ENV['LIB_NAME'] = 'ship_quiet_logistics'
+  Rake::Task['extension:test_app'].invoke
+end

--- a/app/overrides/spree/admin/shipping_methods/_form/add_carrier_and_service_level.html.erb.deface
+++ b/app/overrides/spree/admin/shipping_methods/_form/add_carrier_and_service_level.html.erb.deface
@@ -1,0 +1,10 @@
+<!-- insert_bottom '[data-hook="admin_shipping_method_form_code"]' -->
+<div class="field">
+  <%= f.label :carrier %><br />
+  <%= f.text_field :carrier %>
+</div>
+
+<div class="field">
+  <%= f.label :service_level %><br />
+  <%= f.text_field :service_level %>
+</div>

--- a/bin/rails
+++ b/bin/rails
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails 4 gems installed from the root of your application.
+
+ENGINE_ROOT = File.expand_path('../..', __FILE__)
+ENGINE_PATH = File.expand_path('../../lib/ship_quiet_logistics/engine', __FILE__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+require 'rails/all'
+require 'rails/engine/commands'

--- a/bin/setup
+++ b/bin/setup
@@ -4,5 +4,4 @@ IFS=$'\n\t'
 set -vx
 
 bundle install
-
-# Do any other automated setup that you need to do here
+bundle exec rake test_app

--- a/db/migrate/20160329163708_add_carrier_and_service_level_to_spree_shipping_methods.rb
+++ b/db/migrate/20160329163708_add_carrier_and_service_level_to_spree_shipping_methods.rb
@@ -1,0 +1,6 @@
+class AddCarrierAndServiceLevelToSpreeShippingMethods < ActiveRecord::Migration
+  def change
+    add_column :spree_shipping_methods, :carrier, :string
+    add_column :spree_shipping_methods, :service_level, :string
+  end
+end

--- a/db/migrate/20160329232816_add_pushed_to_spree_shipment.rb
+++ b/db/migrate/20160329232816_add_pushed_to_spree_shipment.rb
@@ -1,0 +1,5 @@
+class AddPushedToSpreeShipment < ActiveRecord::Migration
+  def change
+    add_column :spree_shipments, :pushed, :boolean
+  end
+end

--- a/db/migrate/20160329232816_add_pushed_to_spree_shipment.rb
+++ b/db/migrate/20160329232816_add_pushed_to_spree_shipment.rb
@@ -1,5 +1,7 @@
 class AddPushedToSpreeShipment < ActiveRecord::Migration
   def change
-    add_column :spree_shipments, :pushed, :boolean
+    add_column :spree_shipments, :pushed, :boolean, default: false
+
+    Spree::Shipment.shipped.update_all(pushed: true)
   end
 end

--- a/lib/generators/ship_quiet_logistics/install/install_generator.rb
+++ b/lib/generators/ship_quiet_logistics/install/install_generator.rb
@@ -1,0 +1,20 @@
+module ShipQuietLogistics
+  module Generators
+    class InstallGenerator < Rails::Generators::Base
+      class_option :auto_run_migrations, type: :boolean, default: false
+
+      def add_migrations
+        run 'bundle exec rake railties:install:migrations FROM=ship_quiet_logistics'
+      end
+
+      def run_migrations
+        run_migrations = options[:auto_run_migrations] || ['', 'y', 'Y'].include?(ask 'Would you like to run the migrations now? [Y/n]')
+        if run_migrations
+          run 'bundle exec rake db:migrate'
+        else
+          puts 'Skipping rake db:migrate, don\'t forget to run it!'
+        end
+      end
+    end
+  end
+end

--- a/lib/ship_quiet_logistics.rb
+++ b/lib/ship_quiet_logistics.rb
@@ -1,5 +1,6 @@
 require 'aws-sdk'
 require 'nokogiri'
+require 'spree_core'
 
 require 'ship_quiet_logistics/version'
 require 'ship_quiet_logistics/api'

--- a/lib/ship_quiet_logistics.rb
+++ b/lib/ship_quiet_logistics.rb
@@ -18,16 +18,13 @@ require 'ship_quiet_logistics/sender'
 require 'ship_quiet_logistics/uploader'
 require 'ship_quiet_logistics/version'
 
-AWS.config(access_key_id: ENV['QUIET_AWS_ACCESS_KEY'],
-           secret_access_key: ENV['QUIET_AWS_SECRET_KEY'])
-
 module ShipQuietLogistics
   def self.send_shipment(shipment)
     Commands::SendShipment.(shipment)
   end
 
   def self.process_shipments
-    client = Gentle::Client.new(configuration.credentials)
+    client = Gentle::Client.new(configuration.gentle)
     blackboard = Gentle::Blackboard.new(client)
     queue = Gentle::Queue.new(client)
 
@@ -55,13 +52,20 @@ module ShipQuietLogistics
                   :inventory_queue,
                   :business_unit,
                   :client_id,
+                  :access_key_id,
+                  :secret_access_key,
                   :process_shipment_handler,
                   :error_message_handler
 
-    def credentials
+    def aws
       {
-        access_key_id: ENV['QUIET_AWS_ACCESS_KEY'],
-        secret_access_key: ENV['QUIET_AWS_SECRET_KEY'],
+        access_key_id: access_key_id,
+        secret_access_key: secret_access_key
+      }
+    end
+
+    def gentle
+      aws.merge \
         client_id: client_id,
         business_unit: business_unit,
         warehouse: 'ALL',
@@ -74,7 +78,6 @@ module ShipQuietLogistics
           from: incoming_queue,
           inventory: inventory_queue
         }
-      }
     end
   end
 end

--- a/lib/ship_quiet_logistics.rb
+++ b/lib/ship_quiet_logistics.rb
@@ -3,6 +3,7 @@ require 'nokogiri'
 require 'spree_core'
 
 require 'ship_quiet_logistics/version'
+require 'ship_quiet_logistics/engine'
 require 'ship_quiet_logistics/api'
 require 'ship_quiet_logistics/documents'
 require 'ship_quiet_logistics/commands'

--- a/lib/ship_quiet_logistics.rb
+++ b/lib/ship_quiet_logistics.rb
@@ -15,5 +15,14 @@ require 'ship_quiet_logistics/uploader'
 require 'ship_quiet_logistics/version'
 
 module ShipQuietLogistics
-  # Your code goes here...
+  module Commands
+    class SendShipment
+      def self.call(shipment)
+      end
+    end
+  end
+
+  def self.send_shipment(shipment)
+    Commands::SendShipment.(shipment)
+  end
 end

--- a/lib/ship_quiet_logistics.rb
+++ b/lib/ship_quiet_logistics.rb
@@ -15,6 +15,9 @@ require 'ship_quiet_logistics/sender'
 require 'ship_quiet_logistics/uploader'
 require 'ship_quiet_logistics/version'
 
+AWS.config(access_key_id: ENV['AMAZON_ACCESS_KEY'],
+           secret_access_key: ENV['AMAZON_SECRET_KEY'])
+
 module ShipQuietLogistics
   def self.send_shipment(shipment)
     Commands::SendShipment.(shipment)

--- a/lib/ship_quiet_logistics.rb
+++ b/lib/ship_quiet_logistics.rb
@@ -10,6 +10,7 @@ require 'ship_quiet_logistics/documents'
 require 'ship_quiet_logistics/commands'
 require 'ship_quiet_logistics/downloader'
 require 'ship_quiet_logistics/event_message'
+require 'ship_quiet_logistics/handlers'
 require 'ship_quiet_logistics/messages'
 require 'ship_quiet_logistics/processor'
 require 'ship_quiet_logistics/receiver'
@@ -39,6 +40,9 @@ module ShipQuietLogistics
 
   def self.configure
     self.configuration ||= Configuration.new
+
+    configuration.error_message_handler = Handlers::ErrorMessageHandler
+    configuration.process_shipment_handler = Handlers::ProcessShipmentHandler
 
     yield configuration
   end

--- a/lib/ship_quiet_logistics.rb
+++ b/lib/ship_quiet_logistics.rb
@@ -1,7 +1,7 @@
 require 'aws-sdk'
 require 'nokogiri'
 require 'spree_core'
-require 'hushed'
+require 'gentle'
 
 require 'ship_quiet_logistics/version'
 require 'ship_quiet_logistics/engine'
@@ -26,7 +26,11 @@ module ShipQuietLogistics
   end
 
   def self.process_shipments
-    Commands::ProcessShipments.()
+    client = Gentle::Client.new(configuration.credentials)
+    blackboard = Gentle::Blackboard.new(client)
+    queue = Gentle::Queue.new(client)
+
+    Commands::ProcessShipments.(blackboard: blackboard, queue: queue)
   end
 
   class << self

--- a/lib/ship_quiet_logistics.rb
+++ b/lib/ship_quiet_logistics.rb
@@ -1,6 +1,7 @@
 require 'aws-sdk'
 require 'nokogiri'
 require 'spree_core'
+require 'hushed'
 
 require 'ship_quiet_logistics/version'
 require 'ship_quiet_logistics/engine'

--- a/lib/ship_quiet_logistics.rb
+++ b/lib/ship_quiet_logistics.rb
@@ -51,7 +51,7 @@ module ShipQuietLogistics
                   :inventory_queue,
                   :business_unit,
                   :client_id,
-                  :process_shipment,
+                  :process_shipment_handler,
                   :error_message_handler
 
     def credentials

--- a/lib/ship_quiet_logistics.rb
+++ b/lib/ship_quiet_logistics.rb
@@ -51,7 +51,8 @@ module ShipQuietLogistics
                   :inventory_queue,
                   :business_unit,
                   :client_id,
-                  :process_shipment
+                  :process_shipment,
+                  :error_message_handler
 
     def credentials
       {

--- a/lib/ship_quiet_logistics.rb
+++ b/lib/ship_quiet_logistics.rb
@@ -5,6 +5,7 @@ require 'spree_core'
 require 'ship_quiet_logistics/version'
 require 'ship_quiet_logistics/api'
 require 'ship_quiet_logistics/documents'
+require 'ship_quiet_logistics/commands'
 require 'ship_quiet_logistics/downloader'
 require 'ship_quiet_logistics/event_message'
 require 'ship_quiet_logistics/messages'
@@ -15,13 +16,6 @@ require 'ship_quiet_logistics/uploader'
 require 'ship_quiet_logistics/version'
 
 module ShipQuietLogistics
-  module Commands
-    class SendShipment
-      def self.call(shipment)
-      end
-    end
-  end
-
   def self.send_shipment(shipment)
     Commands::SendShipment.(shipment)
   end

--- a/lib/ship_quiet_logistics.rb
+++ b/lib/ship_quiet_logistics.rb
@@ -17,8 +17,8 @@ require 'ship_quiet_logistics/sender'
 require 'ship_quiet_logistics/uploader'
 require 'ship_quiet_logistics/version'
 
-AWS.config(access_key_id: ENV['AMAZON_ACCESS_KEY'],
-           secret_access_key: ENV['AMAZON_SECRET_KEY'])
+AWS.config(access_key_id: ENV['QUIET_AWS_ACCESS_KEY'],
+           secret_access_key: ENV['QUIET_AWS_SECRET_KEY'])
 
 module ShipQuietLogistics
   def self.send_shipment(shipment)
@@ -48,7 +48,27 @@ module ShipQuietLogistics
                   :outgoing_queue,
                   :incoming_bucket,
                   :incoming_queue,
+                  :inventory_queue,
                   :business_unit,
                   :client_id
+
+    def credentials
+      {
+        access_key_id: ENV['QUIET_AWS_ACCESS_KEY'],
+        secret_access_key: ENV['QUIET_AWS_SECRET_KEY'],
+        client_id: client_id,
+        business_unit: business_unit,
+        warehouse: 'ALL',
+        buckets: {
+          to: outgoing_bucket,
+          from: incoming_bucket
+        },
+        queues: {
+          to: outgoing_queue,
+          from: incoming_queue,
+          inventory: inventory_queue
+        }
+      }
+    end
   end
 end

--- a/lib/ship_quiet_logistics.rb
+++ b/lib/ship_quiet_logistics.rb
@@ -19,4 +19,21 @@ module ShipQuietLogistics
   def self.send_shipment(shipment)
     Commands::SendShipment.(shipment)
   end
+
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= Configuration.new
+
+    yield configuration
+  end
+
+  class Configuration
+    attr_accessor :outgoing_bucket,
+                  :outgoing_queue,
+                  :business_unit,
+                  :client_id
+  end
 end

--- a/lib/ship_quiet_logistics.rb
+++ b/lib/ship_quiet_logistics.rb
@@ -24,6 +24,10 @@ module ShipQuietLogistics
     Commands::SendShipment.(shipment)
   end
 
+  def self.process_shipments
+    Commands::ProcessShipments.()
+  end
+
   class << self
     attr_accessor :configuration
   end
@@ -37,6 +41,8 @@ module ShipQuietLogistics
   class Configuration
     attr_accessor :outgoing_bucket,
                   :outgoing_queue,
+                  :incoming_bucket,
+                  :incoming_queue,
                   :business_unit,
                   :client_id
   end

--- a/lib/ship_quiet_logistics.rb
+++ b/lib/ship_quiet_logistics.rb
@@ -50,7 +50,8 @@ module ShipQuietLogistics
                   :incoming_queue,
                   :inventory_queue,
                   :business_unit,
-                  :client_id
+                  :client_id,
+                  :process_shipment
 
     def credentials
       {

--- a/lib/ship_quiet_logistics/commands.rb
+++ b/lib/ship_quiet_logistics/commands.rb
@@ -1,0 +1,1 @@
+require 'ship_quiet_logistics/commands/send_shipment'

--- a/lib/ship_quiet_logistics/commands.rb
+++ b/lib/ship_quiet_logistics/commands.rb
@@ -1,1 +1,2 @@
 require 'ship_quiet_logistics/commands/send_shipment'
+require 'ship_quiet_logistics/commands/process_shipments'

--- a/lib/ship_quiet_logistics/commands/process_shipments.rb
+++ b/lib/ship_quiet_logistics/commands/process_shipments.rb
@@ -1,0 +1,34 @@
+module ShipQuietLogistics
+  module Commands
+    class ProcessShipments
+      def self.call
+        new.call
+      end
+
+      def initialize
+        @config = ShipQuietLogistics.configuration
+      end
+
+      def call
+        receiver = Receiver.new(queue)
+        receiver.receive_messages do |message|
+          content = Processor.new(bucket).process_doc(message)
+        end
+
+        # do something with the content
+      end
+
+      private
+
+      attr_reader :config
+
+      def queue
+        config.incoming_queue
+      end
+
+      def bucket
+        config.incoming_bucket
+      end
+    end
+  end
+end

--- a/lib/ship_quiet_logistics/commands/process_shipments.rb
+++ b/lib/ship_quiet_logistics/commands/process_shipments.rb
@@ -17,24 +17,14 @@ module ShipQuietLogistics
           document = next_document
           next if document.nil?
 
-          update_shipment(document)
+          # we need to handle an error response
+          config.process_shipment.(document)
         end
       end
 
       private
 
       attr_reader :blackboard, :queue, :config
-
-      def update_shipment(document)
-        shipment = find_shipment(document)
-
-        shipment.ship!
-        shipment.update(tracking: document.tracking_number)
-      end
-
-      def find_shipment(document)
-        Spree::Shipment.find_by(number: document.order_number)
-      end
 
       def next_message
         queue.receive

--- a/lib/ship_quiet_logistics/commands/process_shipments.rb
+++ b/lib/ship_quiet_logistics/commands/process_shipments.rb
@@ -17,7 +17,7 @@ module ShipQuietLogistics
           document = next_document
           next if !document || document.nil?
 
-          config.process_shipment.(document)
+          config.process_shipment_handler.(document)
         end
       end
 

--- a/lib/ship_quiet_logistics/commands/send_shipment.rb
+++ b/lib/ship_quiet_logistics/commands/send_shipment.rb
@@ -1,0 +1,8 @@
+module ShipQuietLogistics
+  module Commands
+    class SendShipment
+      def self.call(shipment)
+      end
+    end
+  end
+end

--- a/lib/ship_quiet_logistics/commands/send_shipment.rb
+++ b/lib/ship_quiet_logistics/commands/send_shipment.rb
@@ -16,6 +16,8 @@ module ShipQuietLogistics
                           config.outgoing_bucket,
                           config.outgoing_queue,
                           configs)
+
+        shipment.update(pushed: true)
       end
 
       private

--- a/lib/ship_quiet_logistics/commands/send_shipment.rb
+++ b/lib/ship_quiet_logistics/commands/send_shipment.rb
@@ -2,6 +2,31 @@ module ShipQuietLogistics
   module Commands
     class SendShipment
       def self.call(shipment)
+        new(shipment).call
+      end
+
+      def initialize(shipment)
+        @shipment = shipment
+        @config = ShipQuietLogistics.configuration
+      end
+
+      def call
+        Api.send_document('ShipmentOrder',
+                          shipment,
+                          config.outgoing_bucket,
+                          config.outgoing_queue,
+                          configs)
+      end
+
+      private
+
+      attr_reader :shipment, :config
+
+      def configs
+        {
+          'client_id' => config.client_id,
+          'business_unit' => config.business_unit
+        }
       end
     end
   end

--- a/lib/ship_quiet_logistics/documents/shipment_order.rb
+++ b/lib/ship_quiet_logistics/documents/shipment_order.rb
@@ -29,8 +29,8 @@ module ShipQuietLogistics
 
               xml.Comments shipment.order.special_instructions
 
-              xml.ShipMode('Carrier'      => shipment['carrier'],
-                           'ServiceLevel' => shipment['service_level'])
+              xml.ShipMode('Carrier'      => shipment.shipping_method.carrier,
+                           'ServiceLevel' => shipment.shipping_method.service_level)
 
               xml.ShipTo(ship_to_hash)
               xml.BillTo(bill_to_hash)

--- a/lib/ship_quiet_logistics/documents/shipment_order.rb
+++ b/lib/ship_quiet_logistics/documents/shipment_order.rb
@@ -23,14 +23,14 @@ module ShipQuietLogistics
 
             xml.OrderHeader('OrderNumber' => shipment_number,
                             'OrderType'   => order_type,
-                            'OrderDate'   => shipment.created_at.utc.iso8601) {
+                            'OrderDate'   => shipment.order_date) {
 
               xml.Extension shipment.order.number
 
               xml.Comments shipment.order.special_instructions
 
-              xml.ShipMode('Carrier'      => shipment.shipping_method.carrier,
-                           'ServiceLevel' => shipment.shipping_method.service_level)
+              xml.ShipMode('Carrier'      => shipment.carrier,
+                           'ServiceLevel' => shipment.service_level)
 
               xml.ShipTo(ship_to_hash)
               xml.BillTo(bill_to_hash)
@@ -63,40 +63,28 @@ module ShipQuietLogistics
 
       def ship_to_hash
         {
-          'Company'    => ship_address.company,
-          'Contact'    => full_name,
-          'Address1'   => ship_address.address1,
-          'Address2'   => ship_address.address2,
-          'City'       => ship_address.city,
-          'State'      => ship_address.state.name,
-          'PostalCode' => ship_address.zipcode,
-          'Country'    => ship_address.country.name
+          'Company'    => shipment.ship_address.company,
+          'Contact'    => shipment.full_name,
+          'Address1'   => shipment.ship_address.address1,
+          'Address2'   => shipment.ship_address.address2,
+          'City'       => shipment.ship_address.city,
+          'State'      => shipment.ship_address.state.name,
+          'PostalCode' => shipment.ship_address.zipcode,
+          'Country'    => shipment.ship_address.country.name
         }
       end
 
       def bill_to_hash
         {
-          'Company'    => bill_address.company,
-          'Contact'    => full_name,
-          'Address1'   => bill_address.address1,
-          'Address2'   => bill_address.address2,
-          'City'       => bill_address.city,
-          'State'      => bill_address.state.name,
-          'PostalCode' => bill_address.zipcode,
-          'Country'    => bill_address.country.name
+          'Company'    => shipment.bill_address.company,
+          'Contact'    => shipment.full_name,
+          'Address1'   => shipment.bill_address.address1,
+          'Address2'   => shipment.bill_address.address2,
+          'City'       => shipment.bill_address.city,
+          'State'      => shipment.bill_address.state.name,
+          'PostalCode' => shipment.bill_address.zipcode,
+          'Country'    => shipment.bill_address.country.name
         }
-      end
-
-      def ship_address
-        shipment.address
-      end
-
-      def bill_address
-        shipment.order.bill_address
-      end
-
-      def full_name
-        ship_address.full_name
       end
 
       def date_stamp

--- a/lib/ship_quiet_logistics/documents/shipment_order.rb
+++ b/lib/ship_quiet_logistics/documents/shipment_order.rb
@@ -1,94 +1,110 @@
 module ShipQuietLogistics
   module Documents
     class ShipmentOrder
-      attr_reader :shipment_number, :order, :shipment, :name, :unit
+      attr_reader :config, :shipment_number, :shipment, :name
 
       def initialize(shipment, config)
         @config          = config
         @shipment        = shipment
-        @shipment_number = shipment['id']
+        @shipment_number = shipment.number
         @name            = "#{@config['business_unit']}_ShipmentOrder_#{@shipment_number}_#{date_stamp}.xml"
+      end
+
+      def message
+        "Succesfully Sent Shipment #{shipment_number} to Quiet Logistics"
       end
 
       def to_xml
         builder = Nokogiri::XML::Builder.new do |xml|
           xml.ShipOrderDocument('xmlns' => 'http://schemas.quietlogistics.com/V2/ShipmentOrder.xsd') {
 
-            xml.ClientID @config['client_id']
-            xml.BusinessUnit @config['business_unit']
+            xml.ClientID config['client_id']
+            xml.BusinessUnit config['business_unit']
 
-            xml.OrderHeader('OrderNumber' => @shipment_number,
-                            'OrderType'   => @shipment['order_type'],
-                            'OrderDate'   => DateTime.now.iso8601) {
+            xml.OrderHeader('OrderNumber' => shipment_number,
+                            'OrderType'   => order_type,
+                            'OrderDate'   => shipment.created_at.utc.iso8601) {
 
-              xml.Extension shipment['order_number']
+              xml.Extension shipment.order.number
 
-              xml.Comments shipment['comments'].to_s
+              xml.Comments shipment.order.special_instructions
 
-              xml.ShipMode('Carrier'      => @shipment['carrier'],
-                           'ServiceLevel' => @shipment['service_level'])
+              xml.ShipMode('Carrier'      => shipment['carrier'],
+                           'ServiceLevel' => shipment['service_level'])
 
               xml.ShipTo(ship_to_hash)
               xml.BillTo(bill_to_hash)
 
-              xml.Notes('NoteType' => @shipment['note_type'].to_s, 'NoteValue' => @shipment['note_value'].to_s)
+              xml.Notes('NoteType' => shipment['note_type'].to_s,
+                        'NoteValue' => shipment['note_value'].to_s)
             }
 
-            @shipment['items'].collect do |item|
+            shipment.order.line_items.collect do |item|
               xml.OrderDetails(line_item_hash(item))
             end
           }
         end
+
         builder.to_xml
       end
 
+      private
+
       def line_item_hash(item)
         {
-          'ItemNumber'      => item["sku"],
-          'Line'            => item['line_number'],
-          'QuantityOrdered' => item['quantity'],
-          'QuantityToShip'  => item['quantity'],
+          'ItemNumber'      => item.sku,
+          'Line'            => item.id,
+          'QuantityOrdered' => item.quantity,
+          'QuantityToShip'  => item.quantity,
           'UOM'             => 'EA',
-          'Price'           => item['price']
+          'Price'           => item.price
         }
       end
 
       def ship_to_hash
         {
-          'Company'    => full_name,
-          'Contact'    => @shipment['shipping_address']['contact'],
-          'Address1'   => @shipment['shipping_address']['address1'],
-          'Address2'   => @shipment['shipping_address']['address2'],
-          'City'       => @shipment['shipping_address']['city'],
-          'State'      => @shipment['shipping_address']['state'],
-          'PostalCode' => @shipment['shipping_address']['zipcode'],
-          'Country'    => @shipment['shipping_address']['country']
+          'Company'    => ship_address.company,
+          'Contact'    => full_name,
+          'Address1'   => ship_address.address1,
+          'Address2'   => ship_address.address2,
+          'City'       => ship_address.city,
+          'State'      => ship_address.state.name,
+          'PostalCode' => ship_address.zipcode,
+          'Country'    => ship_address.country.name
         }
       end
 
       def bill_to_hash
         {
-          'Company'    => full_name,
-          'Contact'    => @shipment['billing_address']['contact'],
-          'Address1'   => @shipment['billing_address']['address1'],
-          'Address2'   => @shipment['billing_address']['address2'],
-          'City'       => @shipment['billing_address']['city'],
-          'State'      => @shipment['billing_address']['state'],
-          'PostalCode' => @shipment['billing_address']['zipcode'],
-          'Country'    => @shipment['billing_address']['country']
+          'Company'    => bill_address.company,
+          'Contact'    => full_name,
+          'Address1'   => bill_address.address1,
+          'Address2'   => bill_address.address2,
+          'City'       => bill_address.city,
+          'State'      => bill_address.state.name,
+          'PostalCode' => bill_address.zipcode,
+          'Country'    => bill_address.country.name
         }
       end
 
-      def full_name
-        "#{shipment['shipping_address']['firstname']} #{@shipment['shipping_address']['lastname']}"
+      def ship_address
+        shipment.address
       end
 
-      def message
-        "Succesfully Sent Shipment #{@shipment_number} to Quiet Logistics"
+      def bill_address
+        shipment.order.bill_address
+      end
+
+      def full_name
+        ship_address.full_name
       end
 
       def date_stamp
         Time.now.strftime('%Y%m%d_%H%M%3N')
+      end
+
+      def order_type
+        'SO'
       end
     end
   end

--- a/lib/ship_quiet_logistics/downloader.rb
+++ b/lib/ship_quiet_logistics/downloader.rb
@@ -5,7 +5,7 @@ module ShipQuietLogistics
     end
 
     def download(file_name)
-      s3 = AWS::S3.new
+      s3 = AWS::S3.new(ShipQuietLogistics.configuration.aws)
       bucket = s3.buckets[@bucket]
       object = bucket.objects[file_name]
 
@@ -19,7 +19,7 @@ module ShipQuietLogistics
     end
 
     def delete_file(name)
-      s3 = AWS::S3.new
+      s3 = AWS::S3.new(ShipQuietLogistics.configuration.aws)
       bucket = s3.buckets[@bucket]
       object = bucket.objects[name]
       object.delete

--- a/lib/ship_quiet_logistics/engine.rb
+++ b/lib/ship_quiet_logistics/engine.rb
@@ -1,0 +1,5 @@
+module ShipQuietLogistics
+  class Engine < ::Rails::Engine
+    isolate_namespace ShipQuietLogistics
+  end
+end

--- a/lib/ship_quiet_logistics/handlers.rb
+++ b/lib/ship_quiet_logistics/handlers.rb
@@ -1,0 +1,2 @@
+require 'ship_quiet_logistics/handlers/error_message_handler'
+require 'ship_quiet_logistics/handlers/process_shipment_handler'

--- a/lib/ship_quiet_logistics/handlers/error_message_handler.rb
+++ b/lib/ship_quiet_logistics/handlers/error_message_handler.rb
@@ -1,0 +1,18 @@
+module ShipQuietLogistics
+  module Handlers
+    class ErrorMessageHandler
+      def self.call(message)
+        shipment = Spree::Shipment.find_by(number: message.shipment_number)
+
+        shipment.update(pushed: false)
+        logger.info(message.to_xml)
+      end
+
+      def self.logger
+        logger = Logger.new('log/fulfillment_event_message_error.log', 'daily')
+        logger.level = Logger::INFO
+        logger
+      end
+    end
+  end
+end

--- a/lib/ship_quiet_logistics/handlers/process_shipment_handler.rb
+++ b/lib/ship_quiet_logistics/handlers/process_shipment_handler.rb
@@ -1,0 +1,12 @@
+module ShipQuietLogistics
+  module Handlers
+    class ProcessShipmentHandler
+      def self.call(document)
+        shipment = Spree::Shipment.find_by(number: document.order_number)
+
+        shipment.ship!
+        shipment.update(tracking: document.tracking_number)
+      end
+    end
+  end
+end

--- a/lib/ship_quiet_logistics/processor.rb
+++ b/lib/ship_quiet_logistics/processor.rb
@@ -5,8 +5,10 @@ module ShipQuietLogistics
     end
 
     def process_doc(msg)
-      name = msg['document_name']
-      type = msg['document_type']
+      name = msg[:document_name]
+      type = msg[:document_type]
+
+      return if type == 'error'
 
       if type == 'InventoryEventMessage'
         data = msg

--- a/lib/ship_quiet_logistics/receiver.rb
+++ b/lib/ship_quiet_logistics/receiver.rb
@@ -2,16 +2,16 @@ module ShipQuietLogistics
   class Receiver
     attr_reader :sqs, :count
 
-    def initialize(queue_name)
-      @sqs = AWS::SQS.new
+    def initialize(queue)
+      @config = ShipQuietLogistics.configuration
+      @sqs = AWS::SQS.new(@config.aws)
       @limit = 10
-      @queue_name = queue_name
+      @queue = queue
       @count = 0
     end
 
     def receive_messages
-      queue = sqs.queues.named(@queue_name)
-
+      queue = sqs.queues[@queue]
 
       4.times do
         queue.receive_message(limit: @limit) do |sqs_message|

--- a/lib/ship_quiet_logistics/sender.rb
+++ b/lib/ship_quiet_logistics/sender.rb
@@ -2,9 +2,10 @@ module ShipQuietLogistics
   class Sender
     attr_reader :sqs
 
-    def initialize(bucket)
-      @sqs = AWS::SQS.new
-      @queue = bucket
+    def initialize(queue)
+      @config = ShipQuietLogistics.configuration
+      @sqs = AWS::SQS.new(@config.aws)
+      @queue = queue
     end
 
     def send_message(event_message)

--- a/lib/ship_quiet_logistics/sender.rb
+++ b/lib/ship_quiet_logistics/sender.rb
@@ -4,11 +4,11 @@ module ShipQuietLogistics
 
     def initialize(bucket)
       @sqs = AWS::SQS.new
-      @queue_name = bucket
+      @queue = bucket
     end
 
     def send_message(event_message)
-      queue = sqs.queues.named(@queue_name)
+      queue = sqs.queues[@queue]
       sqs_message = queue.send_message(event_message.to_xml)
       sqs_message.id
     end

--- a/lib/ship_quiet_logistics/uploader.rb
+++ b/lib/ship_quiet_logistics/uploader.rb
@@ -11,7 +11,7 @@ module ShipQuietLogistics
 
     private
     def upload(name, file)
-      s3 = AWS::S3.new
+      s3 = AWS::S3.new(ShipQuietLogistics.configuration.aws)
       bucket = s3.buckets[@bucket]
 
       s3_object = bucket.objects[name]

--- a/ship_quiet_logistics.gemspec
+++ b/ship_quiet_logistics.gemspec
@@ -39,4 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec-rails', '~> 3.4'
   spec.add_development_dependency 'sqlite3', '~> 1.3'
+  spec.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'
+  spec.add_development_dependency 'webmock', '~> 1.24', '>= 1.24.2'
 end

--- a/ship_quiet_logistics.gemspec
+++ b/ship_quiet_logistics.gemspec
@@ -26,12 +26,17 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'nokogiri', '~> 1.6'
   spec.add_dependency 'aws-sdk', '~> 1.66'
+  spec.add_dependency 'nokogiri', '~> 1.6'
+  spec.add_dependency 'spree_core', '~> 2.4'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'database_cleaner', '~> 1.5'
   spec.add_development_dependency 'dotenv', '~> 2.1'
+  spec.add_development_dependency 'factory_girl', '~> 4.5'
+  spec.add_development_dependency 'ffaker', '~> 1.16'
   spec.add_development_dependency 'pry', '~> 0.10.3'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rspec-rails', '~> 3.4'
+  spec.add_development_dependency 'sqlite3', '~> 1.3'
 end

--- a/ship_quiet_logistics.gemspec
+++ b/ship_quiet_logistics.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec-rails', '~> 3.4'
   spec.add_development_dependency 'sqlite3', '~> 1.3'
+  spec.add_development_dependency 'timecop', '~> 0.8.0'
   spec.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'
   spec.add_development_dependency 'webmock', '~> 1.24', '>= 1.24.2'
 end

--- a/ship_quiet_logistics.gemspec
+++ b/ship_quiet_logistics.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'nokogiri', '~> 1.6'
   spec.add_dependency 'spree_core', '~> 2.4'
-  spec.add_dependency 'hushed', '~> 0.0.9'
+  spec.add_dependency 'gentle', '~> 0.1'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'database_cleaner', '~> 1.5'

--- a/ship_quiet_logistics.gemspec
+++ b/ship_quiet_logistics.gemspec
@@ -30,6 +30,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk', '~> 1.66'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'dotenv', '~> 2.1'
+  spec.add_development_dependency 'pry', '~> 0.10.3'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/ship_quiet_logistics.gemspec
+++ b/ship_quiet_logistics.gemspec
@@ -26,9 +26,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aws-sdk', '~> 1.66'
   spec.add_dependency 'nokogiri', '~> 1.6'
   spec.add_dependency 'spree_core', '~> 2.4'
+  spec.add_dependency 'hushed', '~> 0.0.9'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'database_cleaner', '~> 1.5'

--- a/spec/cassettes/Receiving_shipments_results/an_invalid_shipment_order_result/receives_the_error_result.yml
+++ b/spec/cassettes/Receiving_shipments_results/an_invalid_shipment_order_result/receives_the_error_result.yml
@@ -1,0 +1,244 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=GetQueueAttributes&AttributeName.1=QueueArn&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-30T18%3A09%3A16Z&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      Content-Length:
+      - '193'
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Host:
+      - sqs.us-east-1.amazonaws.com
+      X-Amz-Date:
+      - 20160330T180916Z
+      X-Amz-Content-Sha256:
+      - 65b8daf47e206e17be40dd31dff2279138a77471ae3b9522730c580a6092fa10
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<QUIET_AWS_ACCESS_KEY>/20160330/us-east-1/sqs/aws4_request,
+        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=fda3939ef56e0bb7340d4116d8df8ea4a54a6a44adc240174f6ad0c5f362a9d9
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Server
+      Date:
+      - Wed, 30 Mar 2016 18:09:16 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '392'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 7bd4f5b6-94f0-5728-8e00-bac08c7cd5ba
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><GetQueueAttributesResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-east-1:358309981981:test_aday_from_quiet</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>7bd4f5b6-94f0-5728-8e00-bac08c7cd5ba</RequestId></ResponseMetadata></GetQueueAttributesResponse>
+    http_version: 
+  recorded_at: Wed, 30 Mar 2016 18:09:16 GMT
+- request:
+    method: post
+    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=GetQueueAttributes&AttributeName.1=ApproximateNumberOfMessages&AttributeName.2=QueueArn&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-30T18%3A09%3A16Z&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      Content-Length:
+      - '237'
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Host:
+      - sqs.us-east-1.amazonaws.com
+      X-Amz-Date:
+      - 20160330T180916Z
+      X-Amz-Content-Sha256:
+      - 2ba1ca3dfeeff9da1480ade5c791b66ab719abf15db4d74b574801dd10fb3231
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<QUIET_AWS_ACCESS_KEY>/20160330/us-east-1/sqs/aws4_request,
+        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=5bc7cb4912f3db7996a88f13f3e92bd2384b14eb32bca1375e5d319941a914af
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Server
+      Date:
+      - Wed, 30 Mar 2016 18:09:16 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '471'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 2260fed4-4454-574e-ab76-b1a25cd84130
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><GetQueueAttributesResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueAttributesResult><Attribute><Name>ApproximateNumberOfMessages</Name><Value>1</Value></Attribute><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-east-1:358309981981:test_aday_from_quiet</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>2260fed4-4454-574e-ab76-b1a25cd84130</RequestId></ResponseMetadata></GetQueueAttributesResponse>
+    http_version: 
+  recorded_at: Wed, 30 Mar 2016 18:09:16 GMT
+- request:
+    method: post
+    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-30T18%3A09%3A16Z&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      Content-Length:
+      - '164'
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Host:
+      - sqs.us-east-1.amazonaws.com
+      X-Amz-Date:
+      - 20160330T180916Z
+      X-Amz-Content-Sha256:
+      - 7faeb52f6dadbb040a7a8c9401110d7f5494064e1e7b0003e98b22dd356acaa1
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<QUIET_AWS_ACCESS_KEY>/20160330/us-east-1/sqs/aws4_request,
+        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=070bbc514908fd2b221ee32881eb6bc0ce3be104555cb34bcdc2d060e87e2980
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Server
+      Date:
+      - Wed, 30 Mar 2016 18:09:16 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '3400'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - dcf1ca7c-f7ed-5a2b-867f-850aef617f5c
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;ErrorMessage xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; OriginalMessageId=&quot;668bb744-f9c3-4d24-8474-50a6ff84101c&quot; ResponseDate=&quot;2016-03-30T18:06:58.8003592Z&quot; ClientId=&quot;ADAY&quot; BusinessUnit=&quot;ADAY&quot; ResultCode=&quot;1030&quot; ResultDescription=&quot;Document: ADAY_ShipmentOrder_H22222222222_20160329_2020202.xml - Error: Item SKU-1 not found for ADAY order H22222222222&amp;#xA;&amp;#xA;&amp;lt;?xml version=&amp;quot;1.0&amp;quot;?&amp;gt;&amp;#xA;&amp;lt;ShipOrderDocument xmlns=&amp;quot;http://schemas.quietlogistics.com/V2/ShipmentOrder.xsd&amp;quot;&amp;gt;&amp;#xA;  &amp;lt;ClientID&amp;gt;ADAY&amp;lt;/ClientID&amp;gt;&amp;#xA;  &amp;lt;BusinessUnit&amp;gt;ADAY&amp;lt;/BusinessUnit&amp;gt;&amp;#xA;  &amp;lt;OrderHeader OrderNumber=&amp;quot;H22222222222&amp;quot; OrderType=&amp;quot;SO&amp;quot; OrderDate=&amp;quot;2016-03-30T18:05:56Z&amp;quot;&amp;gt;&amp;#xA;    &amp;lt;Extension&amp;gt;R812830259&amp;lt;/Extension&amp;gt;&amp;#xA;    &amp;lt;Comments/&amp;gt;&amp;#xA;    &amp;lt;ShipMode Carrier=&amp;quot;UPS&amp;quot; ServiceLevel=&amp;quot;GROUND&amp;quot;/&amp;gt;&amp;#xA;    &amp;lt;ShipTo Company=&amp;quot;Company&amp;quot; Contact=&amp;quot;John Doe&amp;quot; Address1=&amp;quot;10 Lovely Street&amp;quot; Address2=&amp;quot;Northwest&amp;quot; City=&amp;quot;Herndon&amp;quot; State=&amp;quot;Alabama&amp;quot; PostalCode=&amp;quot;35005&amp;quot; Country=&amp;quot;United States of America&amp;quot;/&amp;gt;&amp;#xA;    &amp;lt;BillTo Company=&amp;quot;Company&amp;quot; Contact=&amp;quot;John Doe&amp;quot; Address1=&amp;quot;10 Lovely Street&amp;quot; Address2=&amp;quot;Northwest&amp;quot; City=&amp;quot;Herndon&amp;quot; State=&amp;quot;Alabama&amp;quot; PostalCode=&amp;quot;35005&amp;quot; Country=&amp;quot;United States of America&amp;quot;/&amp;gt;&amp;#xA;    &amp;lt;Notes NoteType=&amp;quot;&amp;quot; NoteValue=&amp;quot;&amp;quot;/&amp;gt;&amp;#xA;  &amp;lt;/OrderHeader&amp;gt;&amp;#xA;  &amp;lt;OrderDetails ItemNumber=&amp;quot;SKU-1&amp;quot; Line=&amp;quot;1&amp;quot; QuantityOrdered=&amp;quot;1&amp;quot; QuantityToShip=&amp;quot;1&amp;quot; UOM=&amp;quot;EA&amp;quot; Price=&amp;quot;10.0&amp;quot;/&amp;gt;&amp;#xA;&amp;lt;/ShipOrderDocument&amp;gt;&amp;#xA;&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessageErrorResponse.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/ErrorMessage&gt;</Body><MD5OfBody>abe3c824a49df9694bea78dd863c02da</MD5OfBody><ReceiptHandle>AQEBuleH/SFIHDJ6S0UiEq1h+112jELGA0Y2N3sIWFub7riHuAdTpnzKTo7E0XaiGmBr3u/NdbF0QqiJ1tsbvh/57mnjfcVQpPe/ze0LBRpOx1TnZE2ZjiEXmz881z56udRyjXMoS34HTGdLV+laA24TqQGwFB7Q8ozIRZ8//jEMrv2KSJHibpkYxAIDrg/qRvG01p9oN1dqZD19Jy6slRE0CBbFaEhi08px8YomcIupWjnwEaTuvSvzEKMvTY+FvWMDiIFsFz1SjeajEZCm16buyyNZd2aZdJsvv5hFGJamb4HuiL/J8NcntpMaR7YQ6nUxjCvHaeeIMr+umpVNQdAXGvAwmNzAp3n/nOe/B+Q2SRIpdVWMSnAmaqcie14bvpTpN+Qdp3vueJ9RBgzwLW+xuw==</ReceiptHandle><MessageId>b41e1e44-a287-4852-b58b-3c2498230a60</MessageId></Message></ReceiveMessageResult><ResponseMetadata><RequestId>dcf1ca7c-f7ed-5a2b-867f-850aef617f5c</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Wed, 30 Mar 2016 18:09:16 GMT
+- request:
+    method: post
+    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=DeleteMessage&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&ReceiptHandle=AQEBuleH%2FSFIHDJ6S0UiEq1h%2B112jELGA0Y2N3sIWFub7riHuAdTpnzKTo7E0XaiGmBr3u%2FNdbF0QqiJ1tsbvh%2F57mnjfcVQpPe%2Fze0LBRpOx1TnZE2ZjiEXmz881z56udRyjXMoS34HTGdLV%2BlaA24TqQGwFB7Q8ozIRZ8%2F%2FjEMrv2KSJHibpkYxAIDrg%2FqRvG01p9oN1dqZD19Jy6slRE0CBbFaEhi08px8YomcIupWjnwEaTuvSvzEKMvTY%2BFvWMDiIFsFz1SjeajEZCm16buyyNZd2aZdJsvv5hFGJamb4HuiL%2FJ8NcntpMaR7YQ6nUxjCvHaeeIMr%2BumpVNQdAXGvAwmNzAp3n%2FnOe%2FB%2BQ2SRIpdVWMSnAmaqcie14bvpTpN%2BQdp3vueJ9RBgzwLW%2Bxuw%3D%3D&Timestamp=2016-03-30T18%3A09%3A16Z&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      Content-Length:
+      - '628'
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Host:
+      - sqs.us-east-1.amazonaws.com
+      X-Amz-Date:
+      - 20160330T180916Z
+      X-Amz-Content-Sha256:
+      - 3c4e311fdea4ec848db3908498691767cf2d449d0feaf2ae0f9fa60abea4a8d3
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<QUIET_AWS_ACCESS_KEY>/20160330/us-east-1/sqs/aws4_request,
+        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=bdcfe9a1088b94fe07006b3212062a82ea28f3cd27caee8fb066ea6927acac56
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Server
+      Date:
+      - Wed, 30 Mar 2016 18:09:16 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '215'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - fc4ac9cd-4c27-5f4f-962c-86bb54ab39d6
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><DeleteMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ResponseMetadata><RequestId>fc4ac9cd-4c27-5f4f-962c-86bb54ab39d6</RequestId></ResponseMetadata></DeleteMessageResponse>
+    http_version: 
+  recorded_at: Wed, 30 Mar 2016 18:09:16 GMT
+- request:
+    method: get
+    uri: https://test-aday-from-quiet.s3.amazonaws.com/?versioning=
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Date:
+      - Wed, 30 Mar 2016 18:09:16 GMT
+      Authorization:
+      - AWS <QUIET_AWS_ACCESS_KEY>:ugZJq+gvp4LMfX/jkI3zV0TnTnA=
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - 6pAYSEgdbNpVUgBB9PzQ9cNM+G7cRgamnO0YXN+k2EdhpH/L5nsjCguxV6fbsbU1myPQiOnF0Xo=
+      X-Amz-Request-Id:
+      - 83036EBD93921E2C
+      Date:
+      - Wed, 30 Mar 2016 18:09:18 GMT
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"/>
+    http_version: 
+  recorded_at: Wed, 30 Mar 2016 18:09:17 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/Receiving_shipments_results/receives_the_results.yml
+++ b/spec/cassettes/Receiving_shipments_results/receives_the_results.yml
@@ -2,29 +2,29 @@
 http_interactions:
 - request:
     method: post
-    uri: https://sqs.us-east-1.amazonaws.com/
+    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
     body:
       encoding: UTF-8
-      string: Action=GetQueueUrl&QueueName=test_aday_from_quiet&Timestamp=2016-03-29T19%3A53%3A01Z&Version=2012-11-05
+      string: Action=GetQueueAttributes&AttributeName.1=QueueArn&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-29T23%3A25%3A33Z&Version=2012-11-05
     headers:
       Content-Type:
       - application/x-www-form-urlencoded; charset=utf-8
       Accept-Encoding:
       - ''
       Content-Length:
-      - '103'
+      - '193'
       User-Agent:
       - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
       Host:
       - sqs.us-east-1.amazonaws.com
       X-Amz-Date:
-      - 20160329T195301Z
+      - 20160329T232533Z
       X-Amz-Content-Sha256:
-      - 8653f48856cde85685cc9ee490d778f49210bfc94df977c806e199beb74d7605
+      - bb322ce4bd2d558da36541995194b57157a4cc08e430651bd624209bc8589c56
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=<QUIET_AWS_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
         SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=22c1b13de12359cc5e3b768e366c4493fe89cc5cdfd9a030c5823bcd1fc8f604
+        Signature=521ad3f6fa8248e40bba09b1efd59082fececd637d73f4c437b1267c9f186b38
       Accept:
       - "*/*"
   response:
@@ -35,45 +35,45 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Tue, 29 Mar 2016 19:53:02 GMT
+      - Tue, 29 Mar 2016 23:25:33 GMT
       Content-Type:
       - text/xml
       Content-Length:
-      - '340'
+      - '392'
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 8b6b38da-f26a-53fc-b6b1-77ae2d340ae7
+      - 49b52556-8f1d-5a80-b348-6a239e308c3a
     body:
       encoding: UTF-8
-      string: <?xml version="1.0"?><GetQueueUrlResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueUrlResult><QueueUrl>https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet</QueueUrl></GetQueueUrlResult><ResponseMetadata><RequestId>8b6b38da-f26a-53fc-b6b1-77ae2d340ae7</RequestId></ResponseMetadata></GetQueueUrlResponse>
+      string: <?xml version="1.0"?><GetQueueAttributesResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-east-1:358309981981:test_aday_from_quiet</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>49b52556-8f1d-5a80-b348-6a239e308c3a</RequestId></ResponseMetadata></GetQueueAttributesResponse>
     http_version: 
-  recorded_at: Tue, 29 Mar 2016 19:53:02 GMT
+  recorded_at: Tue, 29 Mar 2016 23:25:33 GMT
 - request:
     method: post
     uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
     body:
       encoding: UTF-8
-      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-29T19%3A53%3A02Z&Version=2012-11-05
+      string: Action=GetQueueAttributes&AttributeName.1=ApproximateNumberOfMessages&AttributeName.2=QueueArn&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-29T23%3A25%3A33Z&Version=2012-11-05
     headers:
       Content-Type:
       - application/x-www-form-urlencoded; charset=utf-8
       Accept-Encoding:
       - ''
       Content-Length:
-      - '187'
+      - '237'
       User-Agent:
       - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
       Host:
       - sqs.us-east-1.amazonaws.com
       X-Amz-Date:
-      - 20160329T195302Z
+      - 20160329T232533Z
       X-Amz-Content-Sha256:
-      - 45aebf8255a0776d6bfd13c1e1a99b744742973f47ac020fe3943a5216cc36cc
+      - 7bd700ea597c5a4159621364f2853ed5725cfedf3b5ba497f1c485b55b486056
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=<QUIET_AWS_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
         SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=e4f7d6c09cfd452db8e37854b3dd713f8eebffd79012ac1734ad73b8eb96d9a5
+        Signature=69f239d5e26ac0dd32aea5ac41dd00b990d45b84e4db4e10827118305f372abd
       Accept:
       - "*/*"
   response:
@@ -84,218 +84,18 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Tue, 29 Mar 2016 19:53:02 GMT
+      - Tue, 29 Mar 2016 23:25:34 GMT
       Content-Type:
       - text/xml
       Content-Length:
-      - '3400'
+      - '471'
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - c5c98908-c5d9-56de-907d-c67c1a8736e7
+      - 23b6b6a3-758b-5e18-ac1e-f9d664a56da0
     body:
       encoding: UTF-8
-      string: |-
-        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
-        &lt;ErrorMessage xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; OriginalMessageId=&quot;438f5183-5b8c-42bb-8086-8714e55e4966&quot; ResponseDate=&quot;2016-03-29T18:16:41.5374299Z&quot; ClientId=&quot;ADAY&quot; BusinessUnit=&quot;ADAY&quot; ResultCode=&quot;1030&quot; ResultDescription=&quot;Document: ADAY_ShipmentOrder_H15535307815_20160329_1415841.xml - Error: Item SKU-1 not found for ADAY order H15535307815&amp;#xA;&amp;#xA;&amp;lt;?xml version=&amp;quot;1.0&amp;quot;?&amp;gt;&amp;#xA;&amp;lt;ShipOrderDocument xmlns=&amp;quot;http://schemas.quietlogistics.com/V2/ShipmentOrder.xsd&amp;quot;&amp;gt;&amp;#xA;  &amp;lt;ClientID&amp;gt;ADAY&amp;lt;/ClientID&amp;gt;&amp;#xA;  &amp;lt;BusinessUnit&amp;gt;ADAY&amp;lt;/BusinessUnit&amp;gt;&amp;#xA;  &amp;lt;OrderHeader OrderNumber=&amp;quot;H15535307815&amp;quot; OrderType=&amp;quot;SO&amp;quot; OrderDate=&amp;quot;2016-03-29T18:15:41Z&amp;quot;&amp;gt;&amp;#xA;    &amp;lt;Extension&amp;gt;R153862122&amp;lt;/Extension&amp;gt;&amp;#xA;    &amp;lt;Comments/&amp;gt;&amp;#xA;    &amp;lt;ShipMode Carrier=&amp;quot;USPS&amp;quot; ServiceLevel=&amp;quot;FIRST&amp;quot;/&amp;gt;&amp;#xA;    &amp;lt;ShipTo Company=&amp;quot;Company&amp;quot; Contact=&amp;quot;John Doe&amp;quot; Address1=&amp;quot;10 Lovely Street&amp;quot; Address2=&amp;quot;Northwest&amp;quot; City=&amp;quot;Herndon&amp;quot; State=&amp;quot;Alabama&amp;quot; PostalCode=&amp;quot;35005&amp;quot; Country=&amp;quot;United States of America&amp;quot;/&amp;gt;&amp;#xA;    &amp;lt;BillTo Company=&amp;quot;Company&amp;quot; Contact=&amp;quot;John Doe&amp;quot; Address1=&amp;quot;10 Lovely Street&amp;quot; Address2=&amp;quot;Northwest&amp;quot; City=&amp;quot;Herndon&amp;quot; State=&amp;quot;Alabama&amp;quot; PostalCode=&amp;quot;35005&amp;quot; Country=&amp;quot;United States of America&amp;quot;/&amp;gt;&amp;#xA;    &amp;lt;Notes NoteType=&amp;quot;&amp;quot; NoteValue=&amp;quot;&amp;quot;/&amp;gt;&amp;#xA;  &amp;lt;/OrderHeader&amp;gt;&amp;#xA;  &amp;lt;OrderDetails ItemNumber=&amp;quot;SKU-1&amp;quot; Line=&amp;quot;1&amp;quot; QuantityOrdered=&amp;quot;1&amp;quot; QuantityToShip=&amp;quot;1&amp;quot; UOM=&amp;quot;EA&amp;quot; Price=&amp;quot;10.0&amp;quot;/&amp;gt;&amp;#xA;&amp;lt;/ShipOrderDocument&amp;gt;&amp;#xA;&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessageErrorResponse.xsd&quot;&gt;&#xD;
-          &lt;Extension /&gt;&#xD;
-        &lt;/ErrorMessage&gt;</Body><ReceiptHandle>AQEB83XdhYNIfXmrcEUQ3nlWfrBrz4bvgTkUlOwZ9H2+aFGzDnvBPZeEmkNPPk5LzJj+7nKX8JGP6/5E3AIoPwf6we6Yw4bLBcHH9fWa2fgd5a9hqjaznJyJaOuIMiM0k/PcCLh4tEaFMFcwMsDjp+gOVoIGftn3sYCavpNWVpvRIPcy/VN3Dca5+XLnrnXJZuhs5zhM32B0qnDSW5ljGS+iOAYSDLTy5xubsfbqoDH0tVSy9JfDElq9v7EeuF0fYeIMaGXpByOdEXXYJx6i74wmzKReakKL61kupDzOqdzMe8LX3Me626q6zcEykacJr698fOSCc0j2URfYBd5x6rMr4u+gFWn0QL0pFjxw43X53O+yZp4O4jQchNBXLNpnf40RCl1yy6vM9RNjWVR0Jqnmtw==</ReceiptHandle><MD5OfBody>09aab6cf73c627e7b08fc621311138a7</MD5OfBody><MessageId>e18d2a6a-4622-4b0e-b98d-38a3b289fcf8</MessageId></Message></ReceiveMessageResult><ResponseMetadata><RequestId>c5c98908-c5d9-56de-907d-c67c1a8736e7</RequestId></ResponseMetadata></ReceiveMessageResponse>
+      string: <?xml version="1.0"?><GetQueueAttributesResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueAttributesResult><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-east-1:358309981981:test_aday_from_quiet</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>23b6b6a3-758b-5e18-ac1e-f9d664a56da0</RequestId></ResponseMetadata></GetQueueAttributesResponse>
     http_version: 
-  recorded_at: Tue, 29 Mar 2016 19:53:02 GMT
-- request:
-    method: post
-    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
-    body:
-      encoding: UTF-8
-      string: Action=DeleteMessage&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&ReceiptHandle=AQEB83XdhYNIfXmrcEUQ3nlWfrBrz4bvgTkUlOwZ9H2%2BaFGzDnvBPZeEmkNPPk5LzJj%2B7nKX8JGP6%2F5E3AIoPwf6we6Yw4bLBcHH9fWa2fgd5a9hqjaznJyJaOuIMiM0k%2FPcCLh4tEaFMFcwMsDjp%2BgOVoIGftn3sYCavpNWVpvRIPcy%2FVN3Dca5%2BXLnrnXJZuhs5zhM32B0qnDSW5ljGS%2BiOAYSDLTy5xubsfbqoDH0tVSy9JfDElq9v7EeuF0fYeIMaGXpByOdEXXYJx6i74wmzKReakKL61kupDzOqdzMe8LX3Me626q6zcEykacJr698fOSCc0j2URfYBd5x6rMr4u%2BgFWn0QL0pFjxw43X53O%2ByZp4O4jQchNBXLNpnf40RCl1yy6vM9RNjWVR0Jqnmtw%3D%3D&Timestamp=2016-03-29T19%3A58%3A12Z&Version=2012-11-05
-    headers:
-      Content-Type:
-      - application/x-www-form-urlencoded; charset=utf-8
-      Accept-Encoding:
-      - ''
-      Content-Length:
-      - '614'
-      User-Agent:
-      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
-      Host:
-      - sqs.us-east-1.amazonaws.com
-      X-Amz-Date:
-      - 20160329T195812Z
-      X-Amz-Content-Sha256:
-      - 55768357f2c075e3df8deab396f54520238f5b0e29bf518e8058b7fcb8427d5c
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
-        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=f343b056020c72b2af7466472df4a67b1f6d50ff926e03d5d7a580390e33cb8f
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Tue, 29 Mar 2016 19:58:12 GMT
-      Content-Type:
-      - text/xml
-      Content-Length:
-      - '215'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - 9e8b3537-b6e2-5029-9c98-7a4356766bee
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0"?><DeleteMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ResponseMetadata><RequestId>9e8b3537-b6e2-5029-9c98-7a4356766bee</RequestId></ResponseMetadata></DeleteMessageResponse>
-    http_version: 
-  recorded_at: Tue, 29 Mar 2016 19:58:12 GMT
-- request:
-    method: post
-    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
-    body:
-      encoding: UTF-8
-      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-29T19%3A58%3A12Z&Version=2012-11-05
-    headers:
-      Content-Type:
-      - application/x-www-form-urlencoded; charset=utf-8
-      Accept-Encoding:
-      - ''
-      Content-Length:
-      - '187'
-      User-Agent:
-      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
-      Host:
-      - sqs.us-east-1.amazonaws.com
-      X-Amz-Date:
-      - 20160329T195812Z
-      X-Amz-Content-Sha256:
-      - 0ed57ad894ef5cb377f6743f25674bd71cfb0a0db32ee117924aadfe1474b458
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
-        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=f2962a4552c685f957f814cfda248b863407526db2bba2a061a4c176b06c38aa
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Tue, 29 Mar 2016 19:58:12 GMT
-      Content-Type:
-      - text/xml
-      Content-Length:
-      - '240'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - a432e3fb-3d45-5f63-8257-ac8fddd17bc0
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult/><ResponseMetadata><RequestId>a432e3fb-3d45-5f63-8257-ac8fddd17bc0</RequestId></ResponseMetadata></ReceiveMessageResponse>
-    http_version: 
-  recorded_at: Tue, 29 Mar 2016 19:58:12 GMT
-- request:
-    method: post
-    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
-    body:
-      encoding: UTF-8
-      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-29T19%3A58%3A12Z&Version=2012-11-05
-    headers:
-      Content-Type:
-      - application/x-www-form-urlencoded; charset=utf-8
-      Accept-Encoding:
-      - ''
-      Content-Length:
-      - '187'
-      User-Agent:
-      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
-      Host:
-      - sqs.us-east-1.amazonaws.com
-      X-Amz-Date:
-      - 20160329T195812Z
-      X-Amz-Content-Sha256:
-      - 0ed57ad894ef5cb377f6743f25674bd71cfb0a0db32ee117924aadfe1474b458
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
-        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=f2962a4552c685f957f814cfda248b863407526db2bba2a061a4c176b06c38aa
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Tue, 29 Mar 2016 19:58:13 GMT
-      Content-Type:
-      - text/xml
-      Content-Length:
-      - '240'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - 539561ba-ffbd-50e4-b0f9-2ece1f282039
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult/><ResponseMetadata><RequestId>539561ba-ffbd-50e4-b0f9-2ece1f282039</RequestId></ResponseMetadata></ReceiveMessageResponse>
-    http_version: 
-  recorded_at: Tue, 29 Mar 2016 19:58:12 GMT
-- request:
-    method: post
-    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
-    body:
-      encoding: UTF-8
-      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-29T19%3A58%3A12Z&Version=2012-11-05
-    headers:
-      Content-Type:
-      - application/x-www-form-urlencoded; charset=utf-8
-      Accept-Encoding:
-      - ''
-      Content-Length:
-      - '187'
-      User-Agent:
-      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
-      Host:
-      - sqs.us-east-1.amazonaws.com
-      X-Amz-Date:
-      - 20160329T195812Z
-      X-Amz-Content-Sha256:
-      - 0ed57ad894ef5cb377f6743f25674bd71cfb0a0db32ee117924aadfe1474b458
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
-        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=f2962a4552c685f957f814cfda248b863407526db2bba2a061a4c176b06c38aa
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Tue, 29 Mar 2016 19:58:13 GMT
-      Content-Type:
-      - text/xml
-      Content-Length:
-      - '240'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - 4055c943-a82c-55eb-a667-863748b9a6d5
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult/><ResponseMetadata><RequestId>4055c943-a82c-55eb-a667-863748b9a6d5</RequestId></ResponseMetadata></ReceiveMessageResponse>
-    http_version: 
-  recorded_at: Tue, 29 Mar 2016 19:58:12 GMT
+  recorded_at: Tue, 29 Mar 2016 23:25:34 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/Receiving_shipments_results/receives_the_results.yml
+++ b/spec/cassettes/Receiving_shipments_results/receives_the_results.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
     body:
       encoding: UTF-8
-      string: Action=GetQueueAttributes&AttributeName.1=QueueArn&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-29T23%3A25%3A33Z&Version=2012-11-05
+      string: Action=GetQueueAttributes&AttributeName.1=QueueArn&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-30T17%3A21%3A33Z&Version=2012-11-05
     headers:
       Content-Type:
       - application/x-www-form-urlencoded; charset=utf-8
@@ -18,13 +18,13 @@ http_interactions:
       Host:
       - sqs.us-east-1.amazonaws.com
       X-Amz-Date:
-      - 20160329T232533Z
+      - 20160330T172133Z
       X-Amz-Content-Sha256:
-      - bb322ce4bd2d558da36541995194b57157a4cc08e430651bd624209bc8589c56
+      - 7d7acede88dcf529fbe007f6a207fe266478ef41a8c865bdcc4fc5098b3f2be5
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=<QUIET_AWS_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=<QUIET_AWS_ACCESS_KEY>/20160330/us-east-1/sqs/aws4_request,
         SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=521ad3f6fa8248e40bba09b1efd59082fececd637d73f4c437b1267c9f186b38
+        Signature=80b9bead27174f610a1d099e454804f0bad1f472341e6889d68b88cae03ad40e
       Accept:
       - "*/*"
   response:
@@ -35,7 +35,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Tue, 29 Mar 2016 23:25:33 GMT
+      - Wed, 30 Mar 2016 17:21:33 GMT
       Content-Type:
       - text/xml
       Content-Length:
@@ -43,18 +43,18 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 49b52556-8f1d-5a80-b348-6a239e308c3a
+      - 63d23634-81f5-54ac-90d4-79428ca8fed2
     body:
       encoding: UTF-8
-      string: <?xml version="1.0"?><GetQueueAttributesResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-east-1:358309981981:test_aday_from_quiet</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>49b52556-8f1d-5a80-b348-6a239e308c3a</RequestId></ResponseMetadata></GetQueueAttributesResponse>
+      string: <?xml version="1.0"?><GetQueueAttributesResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-east-1:358309981981:test_aday_from_quiet</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>63d23634-81f5-54ac-90d4-79428ca8fed2</RequestId></ResponseMetadata></GetQueueAttributesResponse>
     http_version: 
-  recorded_at: Tue, 29 Mar 2016 23:25:33 GMT
+  recorded_at: Wed, 30 Mar 2016 17:21:33 GMT
 - request:
     method: post
     uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
     body:
       encoding: UTF-8
-      string: Action=GetQueueAttributes&AttributeName.1=ApproximateNumberOfMessages&AttributeName.2=QueueArn&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-29T23%3A25%3A33Z&Version=2012-11-05
+      string: Action=GetQueueAttributes&AttributeName.1=ApproximateNumberOfMessages&AttributeName.2=QueueArn&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-30T17%3A21%3A33Z&Version=2012-11-05
     headers:
       Content-Type:
       - application/x-www-form-urlencoded; charset=utf-8
@@ -67,13 +67,13 @@ http_interactions:
       Host:
       - sqs.us-east-1.amazonaws.com
       X-Amz-Date:
-      - 20160329T232533Z
+      - 20160330T172133Z
       X-Amz-Content-Sha256:
-      - 7bd700ea597c5a4159621364f2853ed5725cfedf3b5ba497f1c485b55b486056
+      - b8f20034c5f24ac54ddce804cae63c309cd200fdc08b86a4b912b1afdd1ad9a1
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=<QUIET_AWS_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=<QUIET_AWS_ACCESS_KEY>/20160330/us-east-1/sqs/aws4_request,
         SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=69f239d5e26ac0dd32aea5ac41dd00b990d45b84e4db4e10827118305f372abd
+        Signature=81abb75b2607311e626819545579d423c5866a03bc7e460b46653804efe14b7f
       Accept:
       - "*/*"
   response:
@@ -84,7 +84,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Tue, 29 Mar 2016 23:25:34 GMT
+      - Wed, 30 Mar 2016 17:21:34 GMT
       Content-Type:
       - text/xml
       Content-Length:
@@ -92,10 +92,211 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 23b6b6a3-758b-5e18-ac1e-f9d664a56da0
+      - 77b9b165-a6fe-5477-b505-fe13aba0a2a7
     body:
       encoding: UTF-8
-      string: <?xml version="1.0"?><GetQueueAttributesResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueAttributesResult><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-east-1:358309981981:test_aday_from_quiet</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>23b6b6a3-758b-5e18-ac1e-f9d664a56da0</RequestId></ResponseMetadata></GetQueueAttributesResponse>
+      string: <?xml version="1.0"?><GetQueueAttributesResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueAttributesResult><Attribute><Name>ApproximateNumberOfMessages</Name><Value>1</Value></Attribute><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-east-1:358309981981:test_aday_from_quiet</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>77b9b165-a6fe-5477-b505-fe13aba0a2a7</RequestId></ResponseMetadata></GetQueueAttributesResponse>
     http_version: 
-  recorded_at: Tue, 29 Mar 2016 23:25:34 GMT
+  recorded_at: Wed, 30 Mar 2016 17:21:33 GMT
+- request:
+    method: post
+    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-30T17%3A21%3A33Z&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      Content-Length:
+      - '164'
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Host:
+      - sqs.us-east-1.amazonaws.com
+      X-Amz-Date:
+      - 20160330T172133Z
+      X-Amz-Content-Sha256:
+      - c1fa612108080fa516189ad6e51ecac893dc81be0818c65f10f839460d57e1f1
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<QUIET_AWS_ACCESS_KEY>/20160330/us-east-1/sqs/aws4_request,
+        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=66ed5106e5726da289387fdc7d17d68b7041a86f6b4112568aa8dfc7f6047b75
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Server
+      Date:
+      - Wed, 30 Mar 2016 17:21:34 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1502'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 2c4edad5-8203-5bad-a6d5-95a38f5d0dd1
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;EventMessage xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; MessageId=&quot;fddfbf42-ea7c-49d1-8182-729375cc0ed7&quot; MessageDate=&quot;2016-03-30T17:20:32.5288897Z&quot; DocumentType=&quot;ShipmentOrderResult&quot; ClientId=&quot;ADAY&quot; BusinessUnit=&quot;ADAY&quot; Warehouse=&quot;dvn&quot; DocumentName=&quot;SoResultV2_ADAY_H11111111111_20160330_132028265.xml&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessage.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/EventMessage&gt;</Body><MD5OfBody>7717afdf47e9803b3b6352d3c8f3fb38</MD5OfBody><ReceiptHandle>AQEBbThZdgjjFTaqMuXsxnVADZp9WjXZygHTfb0Yb5U/X7TNlpSKjBMLm3UHZZ1hHa3Ip4JIlPsTmWa3JPQ6mxbubgnpjxkBXs7n2M9ysHXm3AGcbdUR9cvcwONH9soK+mBYAs1yTqJz41wrTZYaCrxGyztiz5smtACxzDI7ePBAEt+7KkSW71oGn1e8Xy4GF4XJaAbf4LkRVoK1vBT1SBv3ybU/oVt4AigYTKLv6NZua+S3Q9OZ1wrCOZm1kVPpwoRtc+RN1sXl7ocCImsCYt9I6aIdKajLLASnWPkvIpf3rJpOOgvzUJ8XwMkKrBSdulNiwltpBKErQ4MpicKATeJQnzhEyj9o8W+CDiEqoWYiEYU+tMkO4j6aBizsxLYJGAu1LVHLLnfT/8jUxfsNoyr9UQ==</ReceiptHandle><MessageId>246104a4-0216-43d2-a822-2cce847868de</MessageId></Message></ReceiveMessageResult><ResponseMetadata><RequestId>2c4edad5-8203-5bad-a6d5-95a38f5d0dd1</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Wed, 30 Mar 2016 17:21:34 GMT
+- request:
+    method: post
+    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=DeleteMessage&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&ReceiptHandle=AQEBbThZdgjjFTaqMuXsxnVADZp9WjXZygHTfb0Yb5U%2FX7TNlpSKjBMLm3UHZZ1hHa3Ip4JIlPsTmWa3JPQ6mxbubgnpjxkBXs7n2M9ysHXm3AGcbdUR9cvcwONH9soK%2BmBYAs1yTqJz41wrTZYaCrxGyztiz5smtACxzDI7ePBAEt%2B7KkSW71oGn1e8Xy4GF4XJaAbf4LkRVoK1vBT1SBv3ybU%2FoVt4AigYTKLv6NZua%2BS3Q9OZ1wrCOZm1kVPpwoRtc%2BRN1sXl7ocCImsCYt9I6aIdKajLLASnWPkvIpf3rJpOOgvzUJ8XwMkKrBSdulNiwltpBKErQ4MpicKATeJQnzhEyj9o8W%2BCDiEqoWYiEYU%2BtMkO4j6aBizsxLYJGAu1LVHLLnfT%2F8jUxfsNoyr9UQ%3D%3D&Timestamp=2016-03-30T17%3A21%3A34Z&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      Content-Length:
+      - '612'
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Host:
+      - sqs.us-east-1.amazonaws.com
+      X-Amz-Date:
+      - 20160330T172134Z
+      X-Amz-Content-Sha256:
+      - d59a7bb6312414f8d4fc9c491f3781e2fee75ba6691f8d943fdacff474c40775
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<QUIET_AWS_ACCESS_KEY>/20160330/us-east-1/sqs/aws4_request,
+        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=a178669908ed9918e34735f83a867db391316117e64e9fc902e1e75971d137c6
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Server
+      Date:
+      - Wed, 30 Mar 2016 17:21:34 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '215'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 90d9e1aa-e6d8-5fdb-85f1-aedceb8679fa
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><DeleteMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ResponseMetadata><RequestId>90d9e1aa-e6d8-5fdb-85f1-aedceb8679fa</RequestId></ResponseMetadata></DeleteMessageResponse>
+    http_version: 
+  recorded_at: Wed, 30 Mar 2016 17:21:34 GMT
+- request:
+    method: get
+    uri: https://test-aday-from-quiet.s3.amazonaws.com/?versioning=
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Date:
+      - Wed, 30 Mar 2016 17:21:34 GMT
+      Authorization:
+      - AWS <QUIET_AWS_ACCESS_KEY>:JNNAN931pAISci2dnyiDiJiOz54=
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - 2LCLhZ6ncnMQ+DlIsGDaNRwhNlP0gofLv2xafJwjOyc/3H29yZpDQ5oRkRtZ8aJXARwgii4Njv0=
+      X-Amz-Request-Id:
+      - CE8249675CF5219E
+      Date:
+      - Wed, 30 Mar 2016 17:21:35 GMT
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"/>
+    http_version: 
+  recorded_at: Wed, 30 Mar 2016 17:21:34 GMT
+- request:
+    method: get
+    uri: https://test-aday-from-quiet.s3.amazonaws.com/SoResultV2_ADAY_H11111111111_20160330_132028265.xml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Date:
+      - Wed, 30 Mar 2016 17:21:34 GMT
+      Authorization:
+      - AWS <QUIET_AWS_ACCESS_KEY>:eI38QRfBIqzCBfZrNEflqXBlQ8k=
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - "+et4qnr1AzlWC4TZVu8s2oNJiS6LsIHIhFXGY67SEOvmIvaeXXJ1Ul+j5KpOEtO4g6wPytzI2u8="
+      X-Amz-Request-Id:
+      - D44A0E06B4E7B845
+      Date:
+      - Wed, 30 Mar 2016 17:21:36 GMT
+      Last-Modified:
+      - Wed, 30 Mar 2016 17:20:35 GMT
+      X-Amz-Expiration:
+      - expiry-date="Thu, 14 Apr 2016 00:00:00 GMT", rule-id="MGIxNGE5MTMtMWI4OC00MTRkLWJlYTMtYjQ2NjQ5MGQwYzNl"
+      Etag:
+      - '"afd95968da8c255b16212d3cf7fc6216"'
+      Accept-Ranges:
+      - bytes
+      Content-Type:
+      - text/plain
+      Content-Length:
+      - '799'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<SOResult xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"
+        xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" ClientID=\"ADAY\" BusinessUnit=\"ADAY\"
+        OrderNumber=\"H11111111111\" DateShipped=\"2016-03-30T17:20:21.9964321Z\"
+        FreightCost=\"0\" CartonCount=\"1\" Warehouse=\"dvn\" xmlns=\"http://schemas.quiettechnology.com/V2/SOResultDocument.xsd\">\r\n
+        \ <Line Line=\"1\" ItemNumber=\"SPREE-T-SHIRT\" Quantity=\"1\" ExceptionCode=\"\"
+        Tax=\"0\" Total=\"0\" SubstitutedItem=\"\" />\r\n  <Carton CartonId=\"S99H11111111111-1\"
+        TrackingId=\"1Z1006639560001\" Carrier=\"UPS\" CartonNumber=\"1\" ServiceLevel=\"GROUND\"
+        Weight=\"1.2\" FreightCost=\"3.05\" HandlingFee=\"0\" Surcharge=\"0\">\r\n
+        \   <Content Line=\"1\" ItemNumber=\"SPREE-T-SHIRT\" Quantity=\"1\" />\r\n
+        \ </Carton>\r\n  <Extension>R762997806</Extension>\r\n</SOResult>"
+    http_version: 
+  recorded_at: Wed, 30 Mar 2016 17:21:35 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/Receiving_shipments_results/receives_the_results.yml
+++ b/spec/cassettes/Receiving_shipments_results/receives_the_results.yml
@@ -1,0 +1,301 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sqs.us-east-1.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=GetQueueUrl&QueueName=test_aday_from_quiet&Timestamp=2016-03-29T19%3A53%3A01Z&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      Content-Length:
+      - '103'
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Host:
+      - sqs.us-east-1.amazonaws.com
+      X-Amz-Date:
+      - 20160329T195301Z
+      X-Amz-Content-Sha256:
+      - 8653f48856cde85685cc9ee490d778f49210bfc94df977c806e199beb74d7605
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
+        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=22c1b13de12359cc5e3b768e366c4493fe89cc5cdfd9a030c5823bcd1fc8f604
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Server
+      Date:
+      - Tue, 29 Mar 2016 19:53:02 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 8b6b38da-f26a-53fc-b6b1-77ae2d340ae7
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><GetQueueUrlResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueUrlResult><QueueUrl>https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet</QueueUrl></GetQueueUrlResult><ResponseMetadata><RequestId>8b6b38da-f26a-53fc-b6b1-77ae2d340ae7</RequestId></ResponseMetadata></GetQueueUrlResponse>
+    http_version: 
+  recorded_at: Tue, 29 Mar 2016 19:53:02 GMT
+- request:
+    method: post
+    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-29T19%3A53%3A02Z&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      Content-Length:
+      - '187'
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Host:
+      - sqs.us-east-1.amazonaws.com
+      X-Amz-Date:
+      - 20160329T195302Z
+      X-Amz-Content-Sha256:
+      - 45aebf8255a0776d6bfd13c1e1a99b744742973f47ac020fe3943a5216cc36cc
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
+        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=e4f7d6c09cfd452db8e37854b3dd713f8eebffd79012ac1734ad73b8eb96d9a5
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Server
+      Date:
+      - Tue, 29 Mar 2016 19:53:02 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '3400'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - c5c98908-c5d9-56de-907d-c67c1a8736e7
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult><Message><Body>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xD;
+        &lt;ErrorMessage xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; xmlns:xsd=&quot;http://www.w3.org/2001/XMLSchema&quot; OriginalMessageId=&quot;438f5183-5b8c-42bb-8086-8714e55e4966&quot; ResponseDate=&quot;2016-03-29T18:16:41.5374299Z&quot; ClientId=&quot;ADAY&quot; BusinessUnit=&quot;ADAY&quot; ResultCode=&quot;1030&quot; ResultDescription=&quot;Document: ADAY_ShipmentOrder_H15535307815_20160329_1415841.xml - Error: Item SKU-1 not found for ADAY order H15535307815&amp;#xA;&amp;#xA;&amp;lt;?xml version=&amp;quot;1.0&amp;quot;?&amp;gt;&amp;#xA;&amp;lt;ShipOrderDocument xmlns=&amp;quot;http://schemas.quietlogistics.com/V2/ShipmentOrder.xsd&amp;quot;&amp;gt;&amp;#xA;  &amp;lt;ClientID&amp;gt;ADAY&amp;lt;/ClientID&amp;gt;&amp;#xA;  &amp;lt;BusinessUnit&amp;gt;ADAY&amp;lt;/BusinessUnit&amp;gt;&amp;#xA;  &amp;lt;OrderHeader OrderNumber=&amp;quot;H15535307815&amp;quot; OrderType=&amp;quot;SO&amp;quot; OrderDate=&amp;quot;2016-03-29T18:15:41Z&amp;quot;&amp;gt;&amp;#xA;    &amp;lt;Extension&amp;gt;R153862122&amp;lt;/Extension&amp;gt;&amp;#xA;    &amp;lt;Comments/&amp;gt;&amp;#xA;    &amp;lt;ShipMode Carrier=&amp;quot;USPS&amp;quot; ServiceLevel=&amp;quot;FIRST&amp;quot;/&amp;gt;&amp;#xA;    &amp;lt;ShipTo Company=&amp;quot;Company&amp;quot; Contact=&amp;quot;John Doe&amp;quot; Address1=&amp;quot;10 Lovely Street&amp;quot; Address2=&amp;quot;Northwest&amp;quot; City=&amp;quot;Herndon&amp;quot; State=&amp;quot;Alabama&amp;quot; PostalCode=&amp;quot;35005&amp;quot; Country=&amp;quot;United States of America&amp;quot;/&amp;gt;&amp;#xA;    &amp;lt;BillTo Company=&amp;quot;Company&amp;quot; Contact=&amp;quot;John Doe&amp;quot; Address1=&amp;quot;10 Lovely Street&amp;quot; Address2=&amp;quot;Northwest&amp;quot; City=&amp;quot;Herndon&amp;quot; State=&amp;quot;Alabama&amp;quot; PostalCode=&amp;quot;35005&amp;quot; Country=&amp;quot;United States of America&amp;quot;/&amp;gt;&amp;#xA;    &amp;lt;Notes NoteType=&amp;quot;&amp;quot; NoteValue=&amp;quot;&amp;quot;/&amp;gt;&amp;#xA;  &amp;lt;/OrderHeader&amp;gt;&amp;#xA;  &amp;lt;OrderDetails ItemNumber=&amp;quot;SKU-1&amp;quot; Line=&amp;quot;1&amp;quot; QuantityOrdered=&amp;quot;1&amp;quot; QuantityToShip=&amp;quot;1&amp;quot; UOM=&amp;quot;EA&amp;quot; Price=&amp;quot;10.0&amp;quot;/&amp;gt;&amp;#xA;&amp;lt;/ShipOrderDocument&amp;gt;&amp;#xA;&quot; xmlns=&quot;http://schemas.quietlogistics.com/V2/EventMessageErrorResponse.xsd&quot;&gt;&#xD;
+          &lt;Extension /&gt;&#xD;
+        &lt;/ErrorMessage&gt;</Body><ReceiptHandle>AQEB83XdhYNIfXmrcEUQ3nlWfrBrz4bvgTkUlOwZ9H2+aFGzDnvBPZeEmkNPPk5LzJj+7nKX8JGP6/5E3AIoPwf6we6Yw4bLBcHH9fWa2fgd5a9hqjaznJyJaOuIMiM0k/PcCLh4tEaFMFcwMsDjp+gOVoIGftn3sYCavpNWVpvRIPcy/VN3Dca5+XLnrnXJZuhs5zhM32B0qnDSW5ljGS+iOAYSDLTy5xubsfbqoDH0tVSy9JfDElq9v7EeuF0fYeIMaGXpByOdEXXYJx6i74wmzKReakKL61kupDzOqdzMe8LX3Me626q6zcEykacJr698fOSCc0j2URfYBd5x6rMr4u+gFWn0QL0pFjxw43X53O+yZp4O4jQchNBXLNpnf40RCl1yy6vM9RNjWVR0Jqnmtw==</ReceiptHandle><MD5OfBody>09aab6cf73c627e7b08fc621311138a7</MD5OfBody><MessageId>e18d2a6a-4622-4b0e-b98d-38a3b289fcf8</MessageId></Message></ReceiveMessageResult><ResponseMetadata><RequestId>c5c98908-c5d9-56de-907d-c67c1a8736e7</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Tue, 29 Mar 2016 19:53:02 GMT
+- request:
+    method: post
+    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=DeleteMessage&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&ReceiptHandle=AQEB83XdhYNIfXmrcEUQ3nlWfrBrz4bvgTkUlOwZ9H2%2BaFGzDnvBPZeEmkNPPk5LzJj%2B7nKX8JGP6%2F5E3AIoPwf6we6Yw4bLBcHH9fWa2fgd5a9hqjaznJyJaOuIMiM0k%2FPcCLh4tEaFMFcwMsDjp%2BgOVoIGftn3sYCavpNWVpvRIPcy%2FVN3Dca5%2BXLnrnXJZuhs5zhM32B0qnDSW5ljGS%2BiOAYSDLTy5xubsfbqoDH0tVSy9JfDElq9v7EeuF0fYeIMaGXpByOdEXXYJx6i74wmzKReakKL61kupDzOqdzMe8LX3Me626q6zcEykacJr698fOSCc0j2URfYBd5x6rMr4u%2BgFWn0QL0pFjxw43X53O%2ByZp4O4jQchNBXLNpnf40RCl1yy6vM9RNjWVR0Jqnmtw%3D%3D&Timestamp=2016-03-29T19%3A58%3A12Z&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      Content-Length:
+      - '614'
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Host:
+      - sqs.us-east-1.amazonaws.com
+      X-Amz-Date:
+      - 20160329T195812Z
+      X-Amz-Content-Sha256:
+      - 55768357f2c075e3df8deab396f54520238f5b0e29bf518e8058b7fcb8427d5c
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
+        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=f343b056020c72b2af7466472df4a67b1f6d50ff926e03d5d7a580390e33cb8f
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Server
+      Date:
+      - Tue, 29 Mar 2016 19:58:12 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '215'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 9e8b3537-b6e2-5029-9c98-7a4356766bee
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><DeleteMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ResponseMetadata><RequestId>9e8b3537-b6e2-5029-9c98-7a4356766bee</RequestId></ResponseMetadata></DeleteMessageResponse>
+    http_version: 
+  recorded_at: Tue, 29 Mar 2016 19:58:12 GMT
+- request:
+    method: post
+    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-29T19%3A58%3A12Z&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      Content-Length:
+      - '187'
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Host:
+      - sqs.us-east-1.amazonaws.com
+      X-Amz-Date:
+      - 20160329T195812Z
+      X-Amz-Content-Sha256:
+      - 0ed57ad894ef5cb377f6743f25674bd71cfb0a0db32ee117924aadfe1474b458
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
+        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=f2962a4552c685f957f814cfda248b863407526db2bba2a061a4c176b06c38aa
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Server
+      Date:
+      - Tue, 29 Mar 2016 19:58:12 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '240'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - a432e3fb-3d45-5f63-8257-ac8fddd17bc0
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult/><ResponseMetadata><RequestId>a432e3fb-3d45-5f63-8257-ac8fddd17bc0</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Tue, 29 Mar 2016 19:58:12 GMT
+- request:
+    method: post
+    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-29T19%3A58%3A12Z&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      Content-Length:
+      - '187'
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Host:
+      - sqs.us-east-1.amazonaws.com
+      X-Amz-Date:
+      - 20160329T195812Z
+      X-Amz-Content-Sha256:
+      - 0ed57ad894ef5cb377f6743f25674bd71cfb0a0db32ee117924aadfe1474b458
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
+        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=f2962a4552c685f957f814cfda248b863407526db2bba2a061a4c176b06c38aa
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Server
+      Date:
+      - Tue, 29 Mar 2016 19:58:13 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '240'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 539561ba-ffbd-50e4-b0f9-2ece1f282039
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult/><ResponseMetadata><RequestId>539561ba-ffbd-50e4-b0f9-2ece1f282039</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Tue, 29 Mar 2016 19:58:12 GMT
+- request:
+    method: post
+    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_from_quiet
+    body:
+      encoding: UTF-8
+      string: Action=ReceiveMessage&MaxNumberOfMessages=10&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_from_quiet&Timestamp=2016-03-29T19%3A58%3A12Z&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      Content-Length:
+      - '187'
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Host:
+      - sqs.us-east-1.amazonaws.com
+      X-Amz-Date:
+      - 20160329T195812Z
+      X-Amz-Content-Sha256:
+      - 0ed57ad894ef5cb377f6743f25674bd71cfb0a0db32ee117924aadfe1474b458
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
+        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=f2962a4552c685f957f814cfda248b863407526db2bba2a061a4c176b06c38aa
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Server
+      Date:
+      - Tue, 29 Mar 2016 19:58:13 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '240'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 4055c943-a82c-55eb-a667-863748b9a6d5
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><ReceiveMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><ReceiveMessageResult/><ResponseMetadata><RequestId>4055c943-a82c-55eb-a667-863748b9a6d5</RequestId></ResponseMetadata></ReceiveMessageResponse>
+    http_version: 
+  recorded_at: Tue, 29 Mar 2016 19:58:12 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/Sending_shipment_orders/an_invalid_shipment_order/sends_the_shipment.yml
+++ b/spec/cassettes/Sending_shipment_orders/an_invalid_shipment_order/sends_the_shipment.yml
@@ -1,0 +1,113 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://test-aday-to-quiet.s3.amazonaws.com/ADAY_ShipmentOrder_H22222222222_20160329_2020202.xml
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <ShipOrderDocument xmlns="http://schemas.quietlogistics.com/V2/ShipmentOrder.xsd">
+          <ClientID>ADAY</ClientID>
+          <BusinessUnit>ADAY</BusinessUnit>
+          <OrderHeader OrderNumber="H22222222222" OrderType="SO" OrderDate="2016-03-30T18:05:56Z">
+            <Extension>R812830259</Extension>
+            <Comments/>
+            <ShipMode Carrier="UPS" ServiceLevel="GROUND"/>
+            <ShipTo Company="Company" Contact="John Doe" Address1="10 Lovely Street" Address2="Northwest" City="Herndon" State="Alabama" PostalCode="35005" Country="United States of America"/>
+            <BillTo Company="Company" Contact="John Doe" Address1="10 Lovely Street" Address2="Northwest" City="Herndon" State="Alabama" PostalCode="35005" Country="United States of America"/>
+            <Notes NoteType="" NoteValue=""/>
+          </OrderHeader>
+          <OrderDetails ItemNumber="SKU-1" Line="1" QuantityOrdered="1" QuantityToShip="1" UOM="EA" Price="10.0"/>
+        </ShipOrderDocument>
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      Content-Length:
+      - '919'
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Expect:
+      - 100-continue
+      Date:
+      - Wed, 30 Mar 2016 18:05:56 GMT
+      Authorization:
+      - AWS <QUIET_AWS_ACCESS_KEY>:bD04UjU29xVIN9XBCQ7bG7uPXRo=
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - fwa7DqBDQRMazKJcESfz8L8/qCr3O15eGskLW2Ma5WxSqPrnhPSQiD1U8+DpOVIK
+      X-Amz-Request-Id:
+      - 468F49051DD9807D
+      Date:
+      - Wed, 30 Mar 2016 18:05:58 GMT
+      X-Amz-Expiration:
+      - expiry-date="Thu, 14 Apr 2016 00:00:00 GMT", rule-id="NDVjZWM3MGUtNzE1NS00NGRiLTliMWYtMmEyYzdlOWE0ZTA3"
+      Etag:
+      - '"142b923940bacbdf74dc77a763485177"'
+      Content-Length:
+      - '0'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Mar 2016 18:05:57 GMT
+- request:
+    method: post
+    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_to_quiet
+    body:
+      encoding: UTF-8
+      string: Action=SendMessage&MessageBody=%3C%3Fxml%20version%3D%221.0%22%3F%3E%0A%3CEventMessage%20xmlns%3D%22http%3A%2F%2Fschemas.quietlogistics.com%2FV2%2FEventMessage.xsd%22%20ClientId%3D%22ADAY%22%20BusinessUnit%3D%22ADAY%22%20DocumentName%3D%22ADAY_ShipmentOrder_H22222222222_20160329_2020202.xml%22%20DocumentType%3D%22ShipmentOrder%22%20MessageId%3D%22668bb744-f9c3-4d24-8474-50a6ff84101c%22%20Warehouse%3D%22DVN%22%20MessageDate%3D%222016-03-30T18%3A05%3A57Z%22%2F%3E%0A&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_to_quiet&Timestamp=2016-03-30T18%3A05%3A57Z&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      Content-Length:
+      - '609'
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Host:
+      - sqs.us-east-1.amazonaws.com
+      X-Amz-Date:
+      - 20160330T180557Z
+      X-Amz-Content-Sha256:
+      - 39a004ee9474a00fcdb31f419488759428182acf35ebad6c220f0b616fab62c8
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<QUIET_AWS_ACCESS_KEY>/20160330/us-east-1/sqs/aws4_request,
+        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=10bf4bc4db0581a50d6cea495d1a42131ad5221bb305b9ce0c8c1f7c257f998f
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Server
+      Date:
+      - Wed, 30 Mar 2016 18:05:57 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '378'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - a22aeb3f-9e50-5ed0-a659-a44989957bb0
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><SendMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><SendMessageResult><MessageId>0a5ddd97-409e-40cc-b56c-680d75252f27</MessageId><MD5OfMessageBody>8786c0e7bc078d8d6e28d4eac3c939c0</MD5OfMessageBody></SendMessageResult><ResponseMetadata><RequestId>a22aeb3f-9e50-5ed0-a659-a44989957bb0</RequestId></ResponseMetadata></SendMessageResponse>
+    http_version: 
+  recorded_at: Wed, 30 Mar 2016 18:05:57 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/Sending_shipment_orders/sends_the_shipment.yml
+++ b/spec/cassettes/Sending_shipment_orders/sends_the_shipment.yml
@@ -1,0 +1,162 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://test-aday-to-quiet.s3.amazonaws.com/ADAY_ShipmentOrder_H15535307815_20160329_0123000.xml
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <ShipOrderDocument xmlns="http://schemas.quietlogistics.com/V2/ShipmentOrder.xsd">
+          <ClientID>ADAY</ClientID>
+          <BusinessUnit>ADAY</BusinessUnit>
+          <OrderHeader OrderNumber="H15535307815" OrderType="SO" OrderDate="2016-03-29T05:23:34Z">
+            <Extension>R379437790</Extension>
+            <Comments/>
+            <ShipMode Carrier="" ServiceLevel=""/>
+            <ShipTo Company="Company" Contact="John Doe" Address1="10 Lovely Street" Address2="Northwest" City="Herndon" State="Alabama" PostalCode="35005" Country="United States of America"/>
+            <BillTo Company="Company" Contact="John Doe" Address1="10 Lovely Street" Address2="Northwest" City="Herndon" State="Alabama" PostalCode="35005" Country="United States of America"/>
+            <Notes NoteType="" NoteValue=""/>
+          </OrderHeader>
+          <OrderDetails ItemNumber="SKU-1" Line="1" QuantityOrdered="1" QuantityToShip="1" UOM="EA" Price="10.0"/>
+        </ShipOrderDocument>
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      Content-Length:
+      - '910'
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Expect:
+      - 100-continue
+      Date:
+      - Tue, 29 Mar 2016 05:23:34 GMT
+      Authorization:
+      - AWS <AMAZON_ACCESS_KEY>:uXFFGnhnvpr0AAe2RuzLYU1W0+g=
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - ibafqOSlYm/sK0YFBZ9iT/cqcSCaKc3c0SsQuVvQDkMfoazpRVy+zdnMLaLTT8yLpYAphsF4554=
+      X-Amz-Request-Id:
+      - 0BCCB1B1A7EAFE03
+      Date:
+      - Tue, 29 Mar 2016 05:23:34 GMT
+      X-Amz-Expiration:
+      - expiry-date="Wed, 13 Apr 2016 00:00:00 GMT", rule-id="NDVjZWM3MGUtNzE1NS00NGRiLTliMWYtMmEyYzdlOWE0ZTA3"
+      Etag:
+      - '"a5da620a6287005bb1c3012f83038b04"'
+      Content-Length:
+      - '0'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 29 Mar 2016 05:23:34 GMT
+- request:
+    method: post
+    uri: https://sqs.us-east-1.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=GetQueueUrl&QueueName=test_aday_to_quiet&Timestamp=2016-03-29T05%3A23%3A34Z&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      Content-Length:
+      - '101'
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Host:
+      - sqs.us-east-1.amazonaws.com
+      X-Amz-Date:
+      - 20160329T052334Z
+      X-Amz-Content-Sha256:
+      - 1425b2d696bb26b69c3e8a52b3106f75fd1a08402cca8c2408cb5f19ebc2e3e9
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
+        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=2b7fc6ea7f7c862d54c625343db97965f23c4c116385946ca7d59f86236b8d7d
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Server
+      Date:
+      - Tue, 29 Mar 2016 05:23:34 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '338'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - c74ddbbc-d1ba-568c-b8fb-94c8c22c1313
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><GetQueueUrlResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueUrlResult><QueueUrl>https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_to_quiet</QueueUrl></GetQueueUrlResult><ResponseMetadata><RequestId>c74ddbbc-d1ba-568c-b8fb-94c8c22c1313</RequestId></ResponseMetadata></GetQueueUrlResponse>
+    http_version: 
+  recorded_at: Tue, 29 Mar 2016 05:23:34 GMT
+- request:
+    method: post
+    uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_to_quiet
+    body:
+      encoding: UTF-8
+      string: Action=SendMessage&MessageBody=%3C%3Fxml%20version%3D%221.0%22%3F%3E%0A%3CEventMessage%20xmlns%3D%22http%3A%2F%2Fschemas.quietlogistics.com%2FV2%2FEventMessage.xsd%22%20ClientId%3D%22ADAY%22%20BusinessUnit%3D%22ADAY%22%20DocumentName%3D%22ADAY_ShipmentOrder_H15535307815_20160329_0123000.xml%22%20DocumentType%3D%22ShipmentOrder%22%20MessageId%3D%228594bb63-b07e-48a1-871d-b4e26a4ce478%22%20Warehouse%3D%22DVN%22%20MessageDate%3D%222016-03-29T05%3A23%3A34Z%22%2F%3E%0A&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_to_quiet&Timestamp=2016-03-29T05%3A23%3A34Z&Version=2012-11-05
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      Content-Length:
+      - '609'
+      User-Agent:
+      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
+      Host:
+      - sqs.us-east-1.amazonaws.com
+      X-Amz-Date:
+      - 20160329T052334Z
+      X-Amz-Content-Sha256:
+      - 1167cb99a5ab4d950c8b54d692b3287d1abba4ed95cbdea4ead8ed679bddec56
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
+        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=1df0931491f36ef407bcf5b664e74381b775073805de74f9b1d39554a32a7925
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Server
+      Date:
+      - Tue, 29 Mar 2016 05:23:34 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '378'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - b9816a6d-ebd1-538c-93be-2519f84714e9
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0"?><SendMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><SendMessageResult><MessageId>d269e5c3-55d7-45fe-a241-693889ca8a60</MessageId><MD5OfMessageBody>5339e64ab536d163a6d4558c2e185490</MD5OfMessageBody></SendMessageResult><ResponseMetadata><RequestId>b9816a6d-ebd1-538c-93be-2519f84714e9</RequestId></ResponseMetadata></SendMessageResponse>
+    http_version: 
+  recorded_at: Tue, 29 Mar 2016 05:23:34 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/Sending_shipment_orders/sends_the_shipment.yml
+++ b/spec/cassettes/Sending_shipment_orders/sends_the_shipment.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://test-aday-to-quiet.s3.amazonaws.com/ADAY_ShipmentOrder_H15535307815_20160329_0123000.xml
+    uri: https://test-aday-to-quiet.s3.amazonaws.com/ADAY_ShipmentOrder_H15535307815_20160329_1014000.xml
     body:
       encoding: UTF-8
       string: |
@@ -10,10 +10,10 @@ http_interactions:
         <ShipOrderDocument xmlns="http://schemas.quietlogistics.com/V2/ShipmentOrder.xsd">
           <ClientID>ADAY</ClientID>
           <BusinessUnit>ADAY</BusinessUnit>
-          <OrderHeader OrderNumber="H15535307815" OrderType="SO" OrderDate="2016-03-29T05:23:34Z">
-            <Extension>R379437790</Extension>
+          <OrderHeader OrderNumber="H15535307815" OrderType="SO" OrderDate="2016-03-29T18:15:41Z">
+            <Extension>R153862122</Extension>
             <Comments/>
-            <ShipMode Carrier="" ServiceLevel=""/>
+            <ShipMode Carrier="USPS" ServiceLevel="FIRST"/>
             <ShipTo Company="Company" Contact="John Doe" Address1="10 Lovely Street" Address2="Northwest" City="Herndon" State="Alabama" PostalCode="35005" Country="United States of America"/>
             <BillTo Company="Company" Contact="John Doe" Address1="10 Lovely Street" Address2="Northwest" City="Herndon" State="Alabama" PostalCode="35005" Country="United States of America"/>
             <Notes NoteType="" NoteValue=""/>
@@ -26,15 +26,15 @@ http_interactions:
       Accept-Encoding:
       - ''
       Content-Length:
-      - '910'
+      - '919'
       User-Agent:
       - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
       Expect:
       - 100-continue
       Date:
-      - Tue, 29 Mar 2016 05:23:34 GMT
+      - Tue, 29 Mar 2016 18:15:41 GMT
       Authorization:
-      - AWS <AMAZON_ACCESS_KEY>:uXFFGnhnvpr0AAe2RuzLYU1W0+g=
+      - AWS <AMAZON_ACCESS_KEY>:ZwljM4xVXuD6ybg8UehlGYIDDgI=
       Accept:
       - "*/*"
   response:
@@ -43,15 +43,15 @@ http_interactions:
       message: OK
     headers:
       X-Amz-Id-2:
-      - ibafqOSlYm/sK0YFBZ9iT/cqcSCaKc3c0SsQuVvQDkMfoazpRVy+zdnMLaLTT8yLpYAphsF4554=
+      - kbN99gZtApktM2DGNWyoKmuGBwdWwDAP6WMzJgbRKFR33O+QF/Zxdp7bFKeI8IjEMsiakGDCIJA=
       X-Amz-Request-Id:
-      - 0BCCB1B1A7EAFE03
+      - AAA43DDC3DCB7731
       Date:
-      - Tue, 29 Mar 2016 05:23:34 GMT
+      - Tue, 29 Mar 2016 18:15:43 GMT
       X-Amz-Expiration:
       - expiry-date="Wed, 13 Apr 2016 00:00:00 GMT", rule-id="NDVjZWM3MGUtNzE1NS00NGRiLTliMWYtMmEyYzdlOWE0ZTA3"
       Etag:
-      - '"a5da620a6287005bb1c3012f83038b04"'
+      - '"3a776001adcf0e4a2a01f0ea71668845"'
       Content-Length:
       - '0'
       Server:
@@ -60,13 +60,13 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 29 Mar 2016 05:23:34 GMT
+  recorded_at: Tue, 29 Mar 2016 18:15:42 GMT
 - request:
     method: post
     uri: https://sqs.us-east-1.amazonaws.com/
     body:
       encoding: UTF-8
-      string: Action=GetQueueUrl&QueueName=test_aday_to_quiet&Timestamp=2016-03-29T05%3A23%3A34Z&Version=2012-11-05
+      string: Action=GetQueueUrl&QueueName=test_aday_to_quiet&Timestamp=2016-03-29T18%3A15%3A42Z&Version=2012-11-05
     headers:
       Content-Type:
       - application/x-www-form-urlencoded; charset=utf-8
@@ -79,13 +79,13 @@ http_interactions:
       Host:
       - sqs.us-east-1.amazonaws.com
       X-Amz-Date:
-      - 20160329T052334Z
+      - 20160329T181542Z
       X-Amz-Content-Sha256:
-      - 1425b2d696bb26b69c3e8a52b3106f75fd1a08402cca8c2408cb5f19ebc2e3e9
+      - 1c3b1a5eb1c81be530662c63436f0b3ae0e2b8aa5036ac9954e24b96f7ac58d2
       Authorization:
       - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
         SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=2b7fc6ea7f7c862d54c625343db97965f23c4c116385946ca7d59f86236b8d7d
+        Signature=64c2fcd5a49652a57c49ff79a4050e0f6aca72cf9687d5763d63cf1ea6b008d1
       Accept:
       - "*/*"
   response:
@@ -96,7 +96,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Tue, 29 Mar 2016 05:23:34 GMT
+      - Tue, 29 Mar 2016 18:15:42 GMT
       Content-Type:
       - text/xml
       Content-Length:
@@ -104,18 +104,18 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - c74ddbbc-d1ba-568c-b8fb-94c8c22c1313
+      - e1015169-157a-5d5d-b510-1e1dddf46f09
     body:
       encoding: UTF-8
-      string: <?xml version="1.0"?><GetQueueUrlResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueUrlResult><QueueUrl>https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_to_quiet</QueueUrl></GetQueueUrlResult><ResponseMetadata><RequestId>c74ddbbc-d1ba-568c-b8fb-94c8c22c1313</RequestId></ResponseMetadata></GetQueueUrlResponse>
+      string: <?xml version="1.0"?><GetQueueUrlResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueUrlResult><QueueUrl>https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_to_quiet</QueueUrl></GetQueueUrlResult><ResponseMetadata><RequestId>e1015169-157a-5d5d-b510-1e1dddf46f09</RequestId></ResponseMetadata></GetQueueUrlResponse>
     http_version: 
-  recorded_at: Tue, 29 Mar 2016 05:23:34 GMT
+  recorded_at: Tue, 29 Mar 2016 18:15:42 GMT
 - request:
     method: post
     uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_to_quiet
     body:
       encoding: UTF-8
-      string: Action=SendMessage&MessageBody=%3C%3Fxml%20version%3D%221.0%22%3F%3E%0A%3CEventMessage%20xmlns%3D%22http%3A%2F%2Fschemas.quietlogistics.com%2FV2%2FEventMessage.xsd%22%20ClientId%3D%22ADAY%22%20BusinessUnit%3D%22ADAY%22%20DocumentName%3D%22ADAY_ShipmentOrder_H15535307815_20160329_0123000.xml%22%20DocumentType%3D%22ShipmentOrder%22%20MessageId%3D%228594bb63-b07e-48a1-871d-b4e26a4ce478%22%20Warehouse%3D%22DVN%22%20MessageDate%3D%222016-03-29T05%3A23%3A34Z%22%2F%3E%0A&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_to_quiet&Timestamp=2016-03-29T05%3A23%3A34Z&Version=2012-11-05
+      string: Action=SendMessage&MessageBody=%3C%3Fxml%20version%3D%221.0%22%3F%3E%0A%3CEventMessage%20xmlns%3D%22http%3A%2F%2Fschemas.quietlogistics.com%2FV2%2FEventMessage.xsd%22%20ClientId%3D%22ADAY%22%20BusinessUnit%3D%22ADAY%22%20DocumentName%3D%22ADAY_ShipmentOrder_H15535307815_20160329_1415841.xml%22%20DocumentType%3D%22ShipmentOrder%22%20MessageId%3D%22438f5183-5b8c-42bb-8086-8714e55e4966%22%20Warehouse%3D%22DVN%22%20MessageDate%3D%222016-03-29T18%3A15%3A42Z%22%2F%3E%0A&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_to_quiet&Timestamp=2016-03-29T18%3A15%3A42Z&Version=2012-11-05
     headers:
       Content-Type:
       - application/x-www-form-urlencoded; charset=utf-8
@@ -128,13 +128,13 @@ http_interactions:
       Host:
       - sqs.us-east-1.amazonaws.com
       X-Amz-Date:
-      - 20160329T052334Z
+      - 20160329T181542Z
       X-Amz-Content-Sha256:
-      - 1167cb99a5ab4d950c8b54d692b3287d1abba4ed95cbdea4ead8ed679bddec56
+      - 4999744a30e2abd0fea782f62221d6a2cdc388b501927eb57aad6961e927953e
       Authorization:
       - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
         SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=1df0931491f36ef407bcf5b664e74381b775073805de74f9b1d39554a32a7925
+        Signature=081c33a58b4fe84955a2f283070e4c24ea601595dbf2e19a199325bcd8fb0cf8
       Accept:
       - "*/*"
   response:
@@ -145,7 +145,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Tue, 29 Mar 2016 05:23:34 GMT
+      - Tue, 29 Mar 2016 18:15:42 GMT
       Content-Type:
       - text/xml
       Content-Length:
@@ -153,10 +153,10 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - b9816a6d-ebd1-538c-93be-2519f84714e9
+      - 72bd349f-5f74-54cc-a422-7beb97fac1b0
     body:
       encoding: UTF-8
-      string: <?xml version="1.0"?><SendMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><SendMessageResult><MessageId>d269e5c3-55d7-45fe-a241-693889ca8a60</MessageId><MD5OfMessageBody>5339e64ab536d163a6d4558c2e185490</MD5OfMessageBody></SendMessageResult><ResponseMetadata><RequestId>b9816a6d-ebd1-538c-93be-2519f84714e9</RequestId></ResponseMetadata></SendMessageResponse>
+      string: <?xml version="1.0"?><SendMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><SendMessageResult><MessageId>24895e98-d126-418f-a3f5-0dc776964277</MessageId><MD5OfMessageBody>8d99801943a71b101cb1aa63f03ed142</MD5OfMessageBody></SendMessageResult><ResponseMetadata><RequestId>72bd349f-5f74-54cc-a422-7beb97fac1b0</RequestId></ResponseMetadata></SendMessageResponse>
     http_version: 
-  recorded_at: Tue, 29 Mar 2016 05:23:34 GMT
+  recorded_at: Tue, 29 Mar 2016 18:15:42 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/Sending_shipment_orders/sends_the_shipment.yml
+++ b/spec/cassettes/Sending_shipment_orders/sends_the_shipment.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://test-aday-to-quiet.s3.amazonaws.com/ADAY_ShipmentOrder_H15535307815_20160329_1014000.xml
+    uri: https://test-aday-to-quiet.s3.amazonaws.com/ADAY_ShipmentOrder_H11111111111_20160329_1010101.xml
     body:
       encoding: UTF-8
       string: |
@@ -10,15 +10,15 @@ http_interactions:
         <ShipOrderDocument xmlns="http://schemas.quietlogistics.com/V2/ShipmentOrder.xsd">
           <ClientID>ADAY</ClientID>
           <BusinessUnit>ADAY</BusinessUnit>
-          <OrderHeader OrderNumber="H15535307815" OrderType="SO" OrderDate="2016-03-29T18:15:41Z">
-            <Extension>R153862122</Extension>
+          <OrderHeader OrderNumber="H11111111111" OrderType="SO" OrderDate="2016-03-30T17:09:10Z">
+            <Extension>R762997806</Extension>
             <Comments/>
-            <ShipMode Carrier="USPS" ServiceLevel="FIRST"/>
+            <ShipMode Carrier="UPS" ServiceLevel="GROUND"/>
             <ShipTo Company="Company" Contact="John Doe" Address1="10 Lovely Street" Address2="Northwest" City="Herndon" State="Alabama" PostalCode="35005" Country="United States of America"/>
             <BillTo Company="Company" Contact="John Doe" Address1="10 Lovely Street" Address2="Northwest" City="Herndon" State="Alabama" PostalCode="35005" Country="United States of America"/>
             <Notes NoteType="" NoteValue=""/>
           </OrderHeader>
-          <OrderDetails ItemNumber="SKU-1" Line="1" QuantityOrdered="1" QuantityToShip="1" UOM="EA" Price="10.0"/>
+          <OrderDetails ItemNumber="SPREE-T-SHIRT" Line="1" QuantityOrdered="1" QuantityToShip="1" UOM="EA" Price="10.0"/>
         </ShipOrderDocument>
     headers:
       Content-Type:
@@ -26,15 +26,15 @@ http_interactions:
       Accept-Encoding:
       - ''
       Content-Length:
-      - '919'
+      - '927'
       User-Agent:
       - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
       Expect:
       - 100-continue
       Date:
-      - Tue, 29 Mar 2016 18:15:41 GMT
+      - Wed, 30 Mar 2016 17:09:10 GMT
       Authorization:
-      - AWS <AMAZON_ACCESS_KEY>:ZwljM4xVXuD6ybg8UehlGYIDDgI=
+      - AWS <QUIET_AWS_ACCESS_KEY>:LGLE7KAXnBopKCnSmK8EoIp02sk=
       Accept:
       - "*/*"
   response:
@@ -43,15 +43,15 @@ http_interactions:
       message: OK
     headers:
       X-Amz-Id-2:
-      - kbN99gZtApktM2DGNWyoKmuGBwdWwDAP6WMzJgbRKFR33O+QF/Zxdp7bFKeI8IjEMsiakGDCIJA=
+      - EAOLO+MrcjzAiqJZSdlEs1xlR0CHEa08AE7yeqH22CG9IGdUyblWI6ImNr0cy7rpiuPaaLH5U68=
       X-Amz-Request-Id:
-      - AAA43DDC3DCB7731
+      - 6D26644F6E683BFE
       Date:
-      - Tue, 29 Mar 2016 18:15:43 GMT
+      - Wed, 30 Mar 2016 17:09:11 GMT
       X-Amz-Expiration:
-      - expiry-date="Wed, 13 Apr 2016 00:00:00 GMT", rule-id="NDVjZWM3MGUtNzE1NS00NGRiLTliMWYtMmEyYzdlOWE0ZTA3"
+      - expiry-date="Thu, 14 Apr 2016 00:00:00 GMT", rule-id="NDVjZWM3MGUtNzE1NS00NGRiLTliMWYtMmEyYzdlOWE0ZTA3"
       Etag:
-      - '"3a776001adcf0e4a2a01f0ea71668845"'
+      - '"bdedc0aafcadf03180b91138e4c0d5d8"'
       Content-Length:
       - '0'
       Server:
@@ -60,62 +60,13 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 29 Mar 2016 18:15:42 GMT
-- request:
-    method: post
-    uri: https://sqs.us-east-1.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: Action=GetQueueUrl&QueueName=test_aday_to_quiet&Timestamp=2016-03-29T18%3A15%3A42Z&Version=2012-11-05
-    headers:
-      Content-Type:
-      - application/x-www-form-urlencoded; charset=utf-8
-      Accept-Encoding:
-      - ''
-      Content-Length:
-      - '101'
-      User-Agent:
-      - aws-sdk-ruby/1.66.0 ruby/2.2.3 x86_64-darwin14
-      Host:
-      - sqs.us-east-1.amazonaws.com
-      X-Amz-Date:
-      - 20160329T181542Z
-      X-Amz-Content-Sha256:
-      - 1c3b1a5eb1c81be530662c63436f0b3ae0e2b8aa5036ac9954e24b96f7ac58d2
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
-        SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=64c2fcd5a49652a57c49ff79a4050e0f6aca72cf9687d5763d63cf1ea6b008d1
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Tue, 29 Mar 2016 18:15:42 GMT
-      Content-Type:
-      - text/xml
-      Content-Length:
-      - '338'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - e1015169-157a-5d5d-b510-1e1dddf46f09
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0"?><GetQueueUrlResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><GetQueueUrlResult><QueueUrl>https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_to_quiet</QueueUrl></GetQueueUrlResult><ResponseMetadata><RequestId>e1015169-157a-5d5d-b510-1e1dddf46f09</RequestId></ResponseMetadata></GetQueueUrlResponse>
-    http_version: 
-  recorded_at: Tue, 29 Mar 2016 18:15:42 GMT
+  recorded_at: Wed, 30 Mar 2016 17:09:10 GMT
 - request:
     method: post
     uri: https://sqs.us-east-1.amazonaws.com/358309981981/test_aday_to_quiet
     body:
       encoding: UTF-8
-      string: Action=SendMessage&MessageBody=%3C%3Fxml%20version%3D%221.0%22%3F%3E%0A%3CEventMessage%20xmlns%3D%22http%3A%2F%2Fschemas.quietlogistics.com%2FV2%2FEventMessage.xsd%22%20ClientId%3D%22ADAY%22%20BusinessUnit%3D%22ADAY%22%20DocumentName%3D%22ADAY_ShipmentOrder_H15535307815_20160329_1415841.xml%22%20DocumentType%3D%22ShipmentOrder%22%20MessageId%3D%22438f5183-5b8c-42bb-8086-8714e55e4966%22%20Warehouse%3D%22DVN%22%20MessageDate%3D%222016-03-29T18%3A15%3A42Z%22%2F%3E%0A&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_to_quiet&Timestamp=2016-03-29T18%3A15%3A42Z&Version=2012-11-05
+      string: Action=SendMessage&MessageBody=%3C%3Fxml%20version%3D%221.0%22%3F%3E%0A%3CEventMessage%20xmlns%3D%22http%3A%2F%2Fschemas.quietlogistics.com%2FV2%2FEventMessage.xsd%22%20ClientId%3D%22ADAY%22%20BusinessUnit%3D%22ADAY%22%20DocumentName%3D%22ADAY_ShipmentOrder_H11111111111_20160329_1010101.xml%22%20DocumentType%3D%22ShipmentOrder%22%20MessageId%3D%223138c6f8-5c79-48b5-8344-a047e5a7b458%22%20Warehouse%3D%22DVN%22%20MessageDate%3D%222016-03-30T17%3A09%3A10Z%22%2F%3E%0A&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F358309981981%2Ftest_aday_to_quiet&Timestamp=2016-03-30T17%3A09%3A10Z&Version=2012-11-05
     headers:
       Content-Type:
       - application/x-www-form-urlencoded; charset=utf-8
@@ -128,13 +79,13 @@ http_interactions:
       Host:
       - sqs.us-east-1.amazonaws.com
       X-Amz-Date:
-      - 20160329T181542Z
+      - 20160330T170910Z
       X-Amz-Content-Sha256:
-      - 4999744a30e2abd0fea782f62221d6a2cdc388b501927eb57aad6961e927953e
+      - b7202a183f2288a083e7c57d82ddc4158e7f825ed4358e6c60e868b70f48fe35
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=<AMAZON_ACCESS_KEY>/20160329/us-east-1/sqs/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=<QUIET_AWS_ACCESS_KEY>/20160330/us-east-1/sqs/aws4_request,
         SignedHeaders=content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=081c33a58b4fe84955a2f283070e4c24ea601595dbf2e19a199325bcd8fb0cf8
+        Signature=0249e5093eee0716c7f86513c7a1f4a1c5aeae0cf04284a45cc8c2fbd057a602
       Accept:
       - "*/*"
   response:
@@ -145,7 +96,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Tue, 29 Mar 2016 18:15:42 GMT
+      - Wed, 30 Mar 2016 17:09:11 GMT
       Content-Type:
       - text/xml
       Content-Length:
@@ -153,10 +104,10 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 72bd349f-5f74-54cc-a422-7beb97fac1b0
+      - 22112a78-69f7-5ce0-bfff-650e6380a142
     body:
       encoding: UTF-8
-      string: <?xml version="1.0"?><SendMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><SendMessageResult><MessageId>24895e98-d126-418f-a3f5-0dc776964277</MessageId><MD5OfMessageBody>8d99801943a71b101cb1aa63f03ed142</MD5OfMessageBody></SendMessageResult><ResponseMetadata><RequestId>72bd349f-5f74-54cc-a422-7beb97fac1b0</RequestId></ResponseMetadata></SendMessageResponse>
+      string: <?xml version="1.0"?><SendMessageResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><SendMessageResult><MessageId>a4794fdf-1035-4a41-83df-b586c2d5c02b</MessageId><MD5OfMessageBody>70ba4c21a5ea296f7ab4abe29abf22de</MD5OfMessageBody></SendMessageResult><ResponseMetadata><RequestId>22112a78-69f7-5ce0-bfff-650e6380a142</RequestId></ResponseMetadata></SendMessageResponse>
     http_version: 
-  recorded_at: Tue, 29 Mar 2016 18:15:42 GMT
+  recorded_at: Wed, 30 Mar 2016 17:09:11 GMT
 recorded_with: VCR 3.0.1

--- a/spec/factories/shipment_factory.rb
+++ b/spec/factories/shipment_factory.rb
@@ -1,0 +1,10 @@
+FactoryGirl.modify do
+  factory :shipment, class: Spree::Shipment do
+    association :order, factory: :order_ready_to_ship
+
+    after(:create) do |shipment, _|
+      shipment.address = shipment.order.shipping_address
+      shipment.save
+    end
+  end
+end

--- a/spec/factories/shipment_factory.rb
+++ b/spec/factories/shipment_factory.rb
@@ -1,5 +1,7 @@
 FactoryGirl.modify do
   factory :shipment, class: Spree::Shipment do
+    tracking nil
+    state :ready
     association :order, factory: :order_ready_to_ship
 
     after(:create) do |shipment, _|

--- a/spec/factories/shipment_factory.rb
+++ b/spec/factories/shipment_factory.rb
@@ -4,7 +4,14 @@ FactoryGirl.modify do
     state :ready
     association :order, factory: :order_ready_to_ship
 
-    after(:create) do |shipment, _|
+    transient do
+      sku 'SPREE-T-SHIRT'
+    end
+
+    after(:create) do |shipment, evaluator|
+      line_item = shipment.line_items.first
+      line_item.variant.update(sku: evaluator.sku)
+
       shipment.address = shipment.order.shipping_address
       shipment.save
     end

--- a/spec/factories/shipping_method_factory.rb
+++ b/spec/factories/shipping_method_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.modify do
+  factory :base_shipping_method, class: Spree::ShippingMethod do
+    carrier 'USPS'
+    service_level 'FIRST'
+  end
+end

--- a/spec/factories/shipping_method_factory.rb
+++ b/spec/factories/shipping_method_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.modify do
   factory :base_shipping_method, class: Spree::ShippingMethod do
-    carrier 'USPS'
-    service_level 'FIRST'
+    carrier 'UPS'
+    service_level 'GROUND'
   end
 end

--- a/spec/features/receives_shipment_order_result_spec.rb
+++ b/spec/features/receives_shipment_order_result_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe 'Receiving shipments results', :vcr do
+  let(:shipment) { create(:shipment, number: 'H15535307815') }
+
+  it 'receives the results' do
+    ShipQuietLogistics.process_shipments
+  end
+end

--- a/spec/features/receives_shipment_order_result_spec.rb
+++ b/spec/features/receives_shipment_order_result_spec.rb
@@ -11,4 +11,18 @@ RSpec.describe 'Receiving shipments results', :vcr do
     expect(subject).to be_shipped
     expect(subject.tracking).to eq '1Z1006639560001'
   end
+
+  context 'an invalid shipment order result' do
+    let!(:shipment) { create(:shipment, number: 'H22222222222', sku: 'SKU-1') }
+
+    subject { shipment.reload }
+
+    it 'receives the error result' do
+      ShipQuietLogistics.process_shipments
+
+      expect(subject).to_not be_shipped
+      expect(subject).to_not be_pushed
+      expect(subject.tracking).to be_nil
+    end
+  end
 end

--- a/spec/features/receives_shipment_order_result_spec.rb
+++ b/spec/features/receives_shipment_order_result_spec.rb
@@ -1,9 +1,14 @@
 require 'spec_helper'
 
 RSpec.describe 'Receiving shipments results', :vcr do
-  let(:shipment) { create(:shipment, number: 'H15535307815') }
+  let!(:shipment) { create(:shipment, number: 'H11111111111') }
+
+  subject { shipment.reload }
 
   it 'receives the results' do
     ShipQuietLogistics.process_shipments
+
+    expect(subject).to be_shipped
+    expect(subject.tracking).to eq '1Z1006639560001'
   end
 end

--- a/spec/features/sends_shipment_order_spec.rb
+++ b/spec/features/sends_shipment_order_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Sending shipment orders', :vcr do
-  let(:shipment) { create(:shipment, number: 'H11111111111') }
+  let(:shipment) { decorate(create(:shipment, number: 'H11111111111')) }
 
   before do
     allow_any_instance_of(ShipQuietLogistics::Documents::ShipmentOrder)
@@ -15,7 +15,7 @@ RSpec.describe 'Sending shipment orders', :vcr do
   end
 
   context 'an invalid shipment order' do
-    let(:shipment) { create(:shipment, number: 'H22222222222', sku: 'SKU-1') }
+    let(:shipment) { decorate(create(:shipment, number: 'H22222222222', sku: 'SKU-1')) }
 
     before do
       allow_any_instance_of(ShipQuietLogistics::Documents::ShipmentOrder)
@@ -27,5 +27,9 @@ RSpec.describe 'Sending shipment orders', :vcr do
 
       expect(shipment.reload).to be_pushed
     end
+  end
+
+  def decorate(shipment)
+    ShipmentDecorator.new(shipment)
   end
 end

--- a/spec/features/sends_shipment_order_spec.rb
+++ b/spec/features/sends_shipment_order_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe 'Sending shipment orders', :vcr do
+  let(:shipment) { create(:shipment) }
+
+  it 'sends the shipment' do
+    ShipQuietLogistics.send_shipment(shipment)
+  end
+end

--- a/spec/features/sends_shipment_order_spec.rb
+++ b/spec/features/sends_shipment_order_spec.rb
@@ -13,4 +13,19 @@ RSpec.describe 'Sending shipment orders', :vcr do
 
     expect(shipment.reload).to be_pushed
   end
+
+  context 'an invalid shipment order' do
+    let(:shipment) { create(:shipment, number: 'H22222222222', sku: 'SKU-1') }
+
+    before do
+      allow_any_instance_of(ShipQuietLogistics::Documents::ShipmentOrder)
+        .to receive(:date_stamp) { '20160329_2020202' }
+    end
+
+    it 'sends the shipment' do
+      ShipQuietLogistics.send_shipment(shipment)
+
+      expect(shipment.reload).to be_pushed
+    end
+  end
 end

--- a/spec/features/sends_shipment_order_spec.rb
+++ b/spec/features/sends_shipment_order_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Sending shipment orders', :vcr do
   let(:shipment) { create(:shipment, number: 'H15535307815') }
 
   before do
-    Timecop.freeze 'Tue, 29 Mar 2016 05:23:34 UTC +00:00'
+    Timecop.freeze 2016, 3, 29, 14, 14
   end
 
   it 'sends the shipment' do

--- a/spec/features/sends_shipment_order_spec.rb
+++ b/spec/features/sends_shipment_order_spec.rb
@@ -1,7 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe 'Sending shipment orders', :vcr do
-  let(:shipment) { create(:shipment) }
+  let(:shipment) { create(:shipment, number: 'H15535307815') }
+
+  before do
+    Timecop.freeze 'Tue, 29 Mar 2016 05:23:34 UTC +00:00'
+  end
 
   it 'sends the shipment' do
     ShipQuietLogistics.send_shipment(shipment)

--- a/spec/features/sends_shipment_order_spec.rb
+++ b/spec/features/sends_shipment_order_spec.rb
@@ -1,13 +1,16 @@
 require 'spec_helper'
 
 RSpec.describe 'Sending shipment orders', :vcr do
-  let(:shipment) { create(:shipment, number: 'H15535307815') }
+  let(:shipment) { create(:shipment, number: 'H11111111111') }
 
   before do
-    Timecop.freeze 2016, 3, 29, 14, 14
+    allow_any_instance_of(ShipQuietLogistics::Documents::ShipmentOrder)
+      .to receive(:date_stamp) { '20160329_1010101' }
   end
 
   it 'sends the shipment' do
     ShipQuietLogistics.send_shipment(shipment)
+
+    expect(shipment.reload).to be_pushed
   end
 end

--- a/spec/ship_quiet_logistics/api_spec.rb
+++ b/spec/ship_quiet_logistics/api_spec.rb
@@ -2,16 +2,16 @@ require 'spec_helper'
 
 describe ShipQuietLogistics::Api do
   before do
-    ShipQuietLogistics::Uploader.any_instance.stub(:process)
-    ShipQuietLogistics::Sender.any_instance.stub(:send_message)
+    # ShipQuietLogistics::Uploader.any_instance.stub(:process)
+    # ShipQuietLogistics::Sender.any_instance.stub(:send_message)
   end
 
-  it 'sends shipment order transfer to QL' do
+  xit 'sends shipment order transfer to QL' do
     message = described_class.send_document('ShipmentOrder', Factories.shipment, 'test', 'test', {})
     expect(message).to eq 'Succesfully Sent Shipment 12836 to Quiet Logistics'
   end
 
-  it 'sends rma doc to QL' do
+  xit 'sends rma doc to QL' do
     message = described_class.send_document('RMADocument', Factories.shipment, 'test', 'test', {})
 
     expect(message).to eq 'Sent RMA 12836 to QL'

--- a/spec/ship_quiet_logistics/commands/process_shipments_spec.rb
+++ b/spec/ship_quiet_logistics/commands/process_shipments_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+module ShipQuietLogistics
+  module Commands
+    RSpec.describe ProcessShipments do
+      let(:blackboard) { spy(:blackboard) }
+      let(:queue) { spy(:queue) }
+      let(:message) { Hushed::Message.new }
+
+      subject(:process_shipments!) do
+        described_class.(blackboard: blackboard, queue: queue)
+      end
+
+      context 'with one shipment' do
+        let!(:shipment) { create(:shipment) }
+
+        let!(:result) { shipment_order_result(shipment) }
+
+        before { allow(queue).to receive(:approximate_pending_messages) { 1 } }
+
+        it 'updates the shipment to shipped' do
+          expect(queue).to receive(:receive) { message }
+          expect(blackboard).to receive(:fetch) { result }
+
+          process_shipments!
+
+          expect(shipment.reload).to have_attributes \
+            state: 'shipped', tracking: 'a-tracking-number'
+        end
+      end
+
+      context 'with many shipments' do
+        let!(:shipments) { create_list(:shipment, 2) }
+
+        let!(:results) do
+          shipments.map { |s| shipment_order_result(s) }
+        end
+
+        before { allow(queue).to receive(:approximate_pending_messages) { 2 } }
+
+        it 'processes all the documents' do
+          allow(queue).to receive(:receive) { message }
+
+          expect(blackboard).to receive(:fetch)
+                                  .and_return(*results)
+                                  .exactly(2).times
+
+          process_shipments!
+        end
+      end
+
+      def shipment_order_result(shipment)
+        Hushed::Documents::Response::ShipmentOrderResult.new(
+          io: %(<SOResult OrderNumber="#{shipment.number}">
+              <Line Line="1"/>
+              <Line Line="2"/>
+              <Carton TrackingId="a-tracking-number">
+                <Content Line="1"/>
+                <Content Line="2"/>
+              </Carton>
+            </SOResult>))
+      end
+    end
+  end
+end

--- a/spec/ship_quiet_logistics/commands/process_shipments_spec.rb
+++ b/spec/ship_quiet_logistics/commands/process_shipments_spec.rb
@@ -5,7 +5,7 @@ module ShipQuietLogistics
     RSpec.describe ProcessShipments do
       let(:blackboard) { spy(:blackboard) }
       let(:queue) { spy(:queue) }
-      let(:message) { Hushed::Message.new }
+      let(:message) { Gentle::Message.new }
 
       subject(:process_shipments!) do
         described_class.(blackboard: blackboard, queue: queue)
@@ -50,7 +50,7 @@ module ShipQuietLogistics
       end
 
       def shipment_order_result(shipment)
-        Hushed::Documents::Response::ShipmentOrderResult.new(
+        Gentle::Documents::Response::ShipmentOrderResult.new(
           io: %(<SOResult OrderNumber="#{shipment.number}">
               <Line Line="1"/>
               <Line Line="2"/>

--- a/spec/ship_quiet_logistics/commands/send_shipment_spec.rb
+++ b/spec/ship_quiet_logistics/commands/send_shipment_spec.rb
@@ -13,11 +13,11 @@ module ShipQuietLogistics
           [
             'ShipmentOrder',
             shipment,
-            ENV['OUTGOING_BUCKET'],
-            ENV['OUTGOING_QUEUE'],
+            ENV['QUIET_OUTGOING_BUCKET'],
+            ENV['QUIET_OUTGOING_QUEUE'],
             {
-              'client_id' => ENV['CLIENT_ID'],
-              'business_unit' => ENV['BUSINESS_UNIT']
+              'client_id' => ENV['QUIET_CLIENT_ID'],
+              'business_unit' => ENV['QUIET_BUSINESS_UNIT']
             }
           ]
 

--- a/spec/ship_quiet_logistics/commands/send_shipment_spec.rb
+++ b/spec/ship_quiet_logistics/commands/send_shipment_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+module ShipQuietLogistics
+  module Commands
+    describe SendShipment do
+      describe '.call' do
+        let(:shipment) { double(:shipment) }
+        let(:api) { ShipQuietLogistics::Api }
+
+        subject(:send_shipment!) { described_class.call(shipment) }
+
+        let(:params) do
+          [
+            'ShipmentOrder',
+            shipment,
+            :outgoing_bucket,
+            :outgoing_queue,
+            {
+              'client_id' => :client_id,
+              'business_unit' => :business_unit
+            }
+          ]
+
+        end
+
+        it 'calls into the api with shipment' do
+          expect(api).to receive('send_document').with *params
+
+          send_shipment!
+        end
+      end
+    end
+  end
+end

--- a/spec/ship_quiet_logistics/commands/send_shipment_spec.rb
+++ b/spec/ship_quiet_logistics/commands/send_shipment_spec.rb
@@ -13,11 +13,11 @@ module ShipQuietLogistics
           [
             'ShipmentOrder',
             shipment,
-            :outgoing_bucket,
-            :outgoing_queue,
+            ENV['OUTGOING_BUCKET'],
+            ENV['OUTGOING_QUEUE'],
             {
-              'client_id' => :client_id,
-              'business_unit' => :business_unit
+              'client_id' => ENV['CLIENT_ID'],
+              'business_unit' => ENV['BUSINESS_UNIT']
             }
           ]
 

--- a/spec/ship_quiet_logistics/commands/send_shipment_spec.rb
+++ b/spec/ship_quiet_logistics/commands/send_shipment_spec.rb
@@ -4,7 +4,7 @@ module ShipQuietLogistics
   module Commands
     describe SendShipment do
       describe '.call' do
-        let(:shipment) { double(:shipment) }
+        let(:shipment) { create(:shipment) }
         let(:api) { ShipQuietLogistics::Api }
 
         subject(:send_shipment!) { described_class.call(shipment) }
@@ -24,9 +24,17 @@ module ShipQuietLogistics
         end
 
         it 'calls into the api with shipment' do
-          expect(api).to receive('send_document').with *params
+          expect(api).to receive(:send_document).with *params
 
           send_shipment!
+        end
+
+        it 'marks the shipment pushed' do
+          allow(api).to receive(:send_document)
+
+          send_shipment!
+
+          expect(shipment).to be_pushed
         end
       end
     end

--- a/spec/ship_quiet_logistics/documents/shipment_order_spec.rb
+++ b/spec/ship_quiet_logistics/documents/shipment_order_spec.rb
@@ -1,19 +1,26 @@
 require 'spec_helper'
 
-module ShipQuietLogistics::Documents
-  describe ShipmentOrder do
-    let(:shipment) { Factories.transfer_order_shipment }
+module ShipQuietLogistics
+  module Documents
+    describe ShipmentOrder do
+      let(:shipment) { create(:shipment) }
 
-    subject { ShipmentOrder.new(shipment, {}) }
+      subject(:document) { described_class.new(shipment, {}) }
+      subject(:xml) { Nokogiri::XML(document.to_xml) }
 
-    it 'converts to xml' do
-      xml = Nokogiri::XML(subject.to_xml)
-      xsd = Nokogiri::XML::Schema(File.read('./spec/schemas/shipment_order.xsd'))
+      it 'has the proper name' do
+        expect(document.name).to match /^_ShipmentOrder_#{shipment.number}_.*\.xml/
+      end
 
-      errors = xsd.validate(xml).collect { |error| error }
+      it 'matches the xml schema' do
+        errors = schema.validate xml
 
-      expect(subject.name).to match /^_ShipmentOrder_#{shipment['id']}_.*\.xml/
-      expect(errors).to eq []
+        expect(errors).to be_empty
+      end
+
+      def schema
+        Nokogiri::XML::Schema(File.read('./spec/schemas/shipment_order.xsd'))
+      end
     end
   end
 end

--- a/spec/ship_quiet_logistics/documents/shipment_order_spec.rb
+++ b/spec/ship_quiet_logistics/documents/shipment_order_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module ShipQuietLogistics
   module Documents
     describe ShipmentOrder do
-      let(:shipment) { create(:shipment) }
+      let(:shipment) { decorate(create(:shipment)) }
 
       subject(:document) { described_class.new(shipment, {}) }
       subject(:xml) { Nokogiri::XML(document.to_xml) }
@@ -20,6 +20,10 @@ module ShipQuietLogistics
 
       def schema
         Nokogiri::XML::Schema(File.read('./spec/schemas/shipment_order.xsd'))
+      end
+
+      def decorate(shipment)
+        ShipmentDecorator.new(shipment)
       end
     end
   end

--- a/spec/ship_quiet_logistics_spec.rb
+++ b/spec/ship_quiet_logistics_spec.rb
@@ -17,4 +17,17 @@ describe ShipQuietLogistics do
       send_shipment!
     end
   end
+
+  context 'getting a shipments result' do
+    let(:shipment) { double(:shipment) }
+    let(:command) { ShipQuietLogistics::Commands::ProcessShipments }
+
+    subject(:process_shipments!) { described_class.process_shipments }
+
+    it 'processes the shipments' do
+      expect(command).to receive(:call)
+
+      process_shipments!
+    end
+  end
 end

--- a/spec/ship_quiet_logistics_spec.rb
+++ b/spec/ship_quiet_logistics_spec.rb
@@ -4,4 +4,17 @@ describe ShipQuietLogistics do
   it 'has a version number' do
     expect(ShipQuietLogistics::VERSION).not_to be nil
   end
+
+  context 'sending a shipment' do
+    let(:shipment) { double(:shipment) }
+    let(:command) { ShipQuietLogistics::Commands::SendShipment }
+
+    subject(:send_shipment!) { described_class.send_shipment(shipment) }
+
+    it 'sends the shipment' do
+      expect(command).to receive(:call).with(shipment).and_call_original
+
+      send_shipment!
+    end
+  end
 end

--- a/spec/ship_quiet_logistics_spec.rb
+++ b/spec/ship_quiet_logistics_spec.rb
@@ -12,7 +12,7 @@ describe ShipQuietLogistics do
     subject(:send_shipment!) { described_class.send_shipment(shipment) }
 
     it 'sends the shipment' do
-      expect(command).to receive(:call).with(shipment).and_call_original
+      expect(command).to receive(:call).with shipment
 
       send_shipment!
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,26 @@
-require 'pry'
-require 'support/factories'
+ENV['RAILS_ENV'] = 'test'
+
+begin
+  require File.expand_path('../dummy/config/environment', __FILE__)
+rescue LoadError
+  puts 'Could not load dummy application. Please ensure you have run `bundle exec rake test_app`'
+  exit
+end
+
 require 'ship_quiet_logistics'
+require 'database_cleaner'
+require 'ffaker'
+require 'pry'
+require 'rspec/rails'
+require 'rspec/autorun'
+
+Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
+
+require 'spree/testing_support/factories'
+
+
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+
+  config.use_transactional_fixtures = false
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,9 +13,9 @@ require 'ffaker'
 require 'pry'
 require 'rspec/rails'
 
-Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
-
 require 'spree/testing_support/factories'
+
+Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
 
 ShipQuietLogistics.configure do |config|
   config.outgoing_bucket  = :outgoing_bucket
@@ -26,6 +26,10 @@ end
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
+
+  config.before do
+    FactoryGirl.find_definitions
+  end
 
   config.use_transactional_fixtures = false
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,20 +9,26 @@ end
 
 require 'ship_quiet_logistics'
 require 'database_cleaner'
+require 'dotenv'
 require 'ffaker'
 require 'pry'
 require 'rspec/rails'
 
 require 'spree/testing_support/factories'
 
+Dotenv.load
+
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
 
 ShipQuietLogistics.configure do |config|
-  config.outgoing_bucket  = :outgoing_bucket
-  config.outgoing_queue   = :outgoing_queue
-  config.business_unit    = :business_unit
-  config.client_id        = :client_id
+  config.outgoing_bucket  = ENV['OUTGOING_BUCKET']
+  config.outgoing_queue   = ENV['OUTGOING_QUEUE']
+  config.business_unit    = ENV['BUSINESS_UNIT']
+  config.client_id        = ENV['CLIENT_ID']
 end
+
+AWS.config(access_key_id: ENV['AMAZON_ACCESS_KEY'],
+           secret_access_key: ENV['AMAZON_SECRET_KEY'])
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 ENV['RAILS_ENV'] = 'test'
 
+require 'dotenv'
+Dotenv.load!
+
 begin
   require File.expand_path('../dummy/config/environment', __FILE__)
 rescue LoadError
@@ -7,16 +10,12 @@ rescue LoadError
   exit
 end
 
-require 'ship_quiet_logistics'
 require 'database_cleaner'
-require 'dotenv'
 require 'ffaker'
 require 'pry'
 require 'rspec/rails'
-
 require 'spree/testing_support/factories'
-
-Dotenv.load
+require 'timecop'
 
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
 
@@ -26,6 +25,8 @@ ShipQuietLogistics.configure do |config|
   config.business_unit    = ENV['BUSINESS_UNIT']
   config.client_id        = ENV['CLIENT_ID']
 end
+
+AWS.config(sqs_verify_checksums: false)
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,15 +19,6 @@ require 'timecop'
 
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
 
-ShipQuietLogistics.configure do |config|
-  config.outgoing_bucket  = ENV['OUTGOING_BUCKET']
-  config.outgoing_queue   = ENV['OUTGOING_QUEUE']
-  config.business_unit    = ENV['BUSINESS_UNIT']
-  config.client_id        = ENV['CLIENT_ID']
-end
-
-AWS.config(sqs_verify_checksums: false)
-
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,9 +27,6 @@ ShipQuietLogistics.configure do |config|
   config.client_id        = ENV['CLIENT_ID']
 end
 
-AWS.config(access_key_id: ENV['AMAZON_ACCESS_KEY'],
-           secret_access_key: ENV['AMAZON_SECRET_KEY'])
-
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,6 @@ require 'database_cleaner'
 require 'ffaker'
 require 'pry'
 require 'rspec/rails'
-require 'rspec/autorun'
 
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,12 @@ Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
 
 require 'spree/testing_support/factories'
 
+ShipQuietLogistics.configure do |config|
+  config.outgoing_bucket  = :outgoing_bucket
+  config.outgoing_queue   = :outgoing_queue
+  config.business_unit    = :business_unit
+  config.client_id        = :client_id
+end
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods

--- a/spec/support/configure.rb
+++ b/spec/support/configure.rb
@@ -1,10 +1,11 @@
 ShipQuietLogistics.configure do |config|
-  config.outgoing_bucket  = ENV['OUTGOING_BUCKET']
-  config.outgoing_queue   = ENV['OUTGOING_QUEUE']
-  config.incoming_bucket  = ENV['INCOMING_BUCKET']
-  config.incoming_queue   = ENV['INCOMING_QUEUE']
-  config.business_unit    = ENV['BUSINESS_UNIT']
-  config.client_id        = ENV['CLIENT_ID']
+  config.outgoing_bucket  = ENV['QUIET_OUTGOING_BUCKET']
+  config.outgoing_queue   = ENV['QUIET_OUTGOING_QUEUE']
+  config.incoming_bucket  = ENV['QUIET_INCOMING_BUCKET']
+  config.incoming_queue   = ENV['QUIET_INCOMING_QUEUE']
+  config.inventory_queue  = ENV['QUIET_INVENTORY_QUEUE']
+  config.business_unit    = ENV['QUIET_BUSINESS_UNIT']
+  config.client_id        = ENV['QUIET_CLIENT_ID']
 end
 
 AWS.config(sqs_verify_checksums: false)

--- a/spec/support/configure.rb
+++ b/spec/support/configure.rb
@@ -1,22 +1,3 @@
-module ShipQuietLogistics
-  class DummyProcessShipmentHandler
-    def self.call(document)
-      shipment = Spree::Shipment.find_by(number: document.order_number)
-
-      shipment.ship!
-      shipment.update(tracking: document.tracking_number)
-    end
-  end
-
-  class DummyErrorMessageHandler
-    def self.call(message)
-      shipment = Spree::Shipment.find_by(number: message.shipment_number)
-
-      shipment.update(pushed: false)
-    end
-  end
-end
-
 ShipQuietLogistics.configure do |config|
   config.outgoing_bucket  = ENV['QUIET_OUTGOING_BUCKET']
   config.outgoing_queue   = ENV['QUIET_OUTGOING_QUEUE']
@@ -25,10 +6,6 @@ ShipQuietLogistics.configure do |config|
   config.inventory_queue  = ENV['QUIET_INVENTORY_QUEUE']
   config.business_unit    = ENV['QUIET_BUSINESS_UNIT']
   config.client_id        = ENV['QUIET_CLIENT_ID']
-
-  # This could be anything we can invoke with `.call`
-  config.process_shipment_handler = ShipQuietLogistics::DummyProcessShipmentHandler
-  config.error_message_handler = ShipQuietLogistics::DummyErrorMessageHandler
 end
 
 AWS.config(sqs_verify_checksums: false)

--- a/spec/support/configure.rb
+++ b/spec/support/configure.rb
@@ -1,0 +1,10 @@
+ShipQuietLogistics.configure do |config|
+  config.outgoing_bucket  = ENV['OUTGOING_BUCKET']
+  config.outgoing_queue   = ENV['OUTGOING_QUEUE']
+  config.incoming_bucket  = ENV['INCOMING_BUCKET']
+  config.incoming_queue   = ENV['INCOMING_QUEUE']
+  config.business_unit    = ENV['BUSINESS_UNIT']
+  config.client_id        = ENV['CLIENT_ID']
+end
+
+AWS.config(sqs_verify_checksums: false)

--- a/spec/support/configure.rb
+++ b/spec/support/configure.rb
@@ -7,6 +7,14 @@ module ShipQuietLogistics
       shipment.update(tracking: document.tracking_number)
     end
   end
+
+  class DummyErrorMessageHandler
+    def self.call(message)
+      shipment = Spree::Shipment.find_by(number: message.shipment_number)
+
+      shipment.update(pushed: false)
+    end
+  end
 end
 
 ShipQuietLogistics.configure do |config|
@@ -20,6 +28,7 @@ ShipQuietLogistics.configure do |config|
 
   # This could be anything we can invoke with `.call`
   config.process_shipment = ShipQuietLogistics::DummyProcessShipment
+  config.error_message_handler = ShipQuietLogistics::DummyErrorMessageHandler
 end
 
 AWS.config(sqs_verify_checksums: false)

--- a/spec/support/configure.rb
+++ b/spec/support/configure.rb
@@ -1,3 +1,14 @@
+module ShipQuietLogistics
+  class DummyProcessShipment
+    def self.call(document)
+      shipment = Spree::Shipment.find_by(number: document.order_number)
+
+      shipment.ship!
+      shipment.update(tracking: document.tracking_number)
+    end
+  end
+end
+
 ShipQuietLogistics.configure do |config|
   config.outgoing_bucket  = ENV['QUIET_OUTGOING_BUCKET']
   config.outgoing_queue   = ENV['QUIET_OUTGOING_QUEUE']
@@ -6,6 +17,9 @@ ShipQuietLogistics.configure do |config|
   config.inventory_queue  = ENV['QUIET_INVENTORY_QUEUE']
   config.business_unit    = ENV['QUIET_BUSINESS_UNIT']
   config.client_id        = ENV['QUIET_CLIENT_ID']
+
+  # This could be anything we can invoke with `.call`
+  config.process_shipment = ShipQuietLogistics::DummyProcessShipment
 end
 
 AWS.config(sqs_verify_checksums: false)

--- a/spec/support/configure.rb
+++ b/spec/support/configure.rb
@@ -1,11 +1,13 @@
 ShipQuietLogistics.configure do |config|
-  config.outgoing_bucket  = ENV['QUIET_OUTGOING_BUCKET']
-  config.outgoing_queue   = ENV['QUIET_OUTGOING_QUEUE']
-  config.incoming_bucket  = ENV['QUIET_INCOMING_BUCKET']
-  config.incoming_queue   = ENV['QUIET_INCOMING_QUEUE']
-  config.inventory_queue  = ENV['QUIET_INVENTORY_QUEUE']
-  config.business_unit    = ENV['QUIET_BUSINESS_UNIT']
-  config.client_id        = ENV['QUIET_CLIENT_ID']
+  config.outgoing_bucket   = ENV['QUIET_OUTGOING_BUCKET']
+  config.outgoing_queue    = ENV['QUIET_OUTGOING_QUEUE']
+  config.incoming_bucket   = ENV['QUIET_INCOMING_BUCKET']
+  config.incoming_queue    = ENV['QUIET_INCOMING_QUEUE']
+  config.inventory_queue   = ENV['QUIET_INVENTORY_QUEUE']
+  config.business_unit     = ENV['QUIET_BUSINESS_UNIT']
+  config.client_id         = ENV['QUIET_CLIENT_ID']
+  config.access_key_id     = ENV['QUIET_AWS_ACCESS_KEY']
+  config.secret_access_key = ENV['QUIET_AWS_SECRET_KEY']
 end
 
 AWS.config(sqs_verify_checksums: false)

--- a/spec/support/configure.rb
+++ b/spec/support/configure.rb
@@ -1,5 +1,5 @@
 module ShipQuietLogistics
-  class DummyProcessShipment
+  class DummyProcessShipmentHandler
     def self.call(document)
       shipment = Spree::Shipment.find_by(number: document.order_number)
 
@@ -27,7 +27,7 @@ ShipQuietLogistics.configure do |config|
   config.client_id        = ENV['QUIET_CLIENT_ID']
 
   # This could be anything we can invoke with `.call`
-  config.process_shipment = ShipQuietLogistics::DummyProcessShipment
+  config.process_shipment_handler = ShipQuietLogistics::DummyProcessShipmentHandler
   config.error_message_handler = ShipQuietLogistics::DummyErrorMessageHandler
 end
 

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,14 @@
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+end

--- a/spec/support/shipment_decorator.rb
+++ b/spec/support/shipment_decorator.rb
@@ -1,0 +1,25 @@
+class ShipmentDecorator < SimpleDelegator
+  def bill_address
+    order.bill_address
+  end
+
+  def carrier
+    shipping_method.carrier
+  end
+
+  def service_level
+    shipping_method.service_level
+  end
+
+  def full_name
+    ship_address.full_name
+  end
+
+  def order_date
+    created_at.utc.iso8601
+  end
+
+  def ship_address
+    address
+  end
+end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,7 @@
+require 'vcr'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/cassettes'
+  c.hook_into :webmock
+  c.configure_rspec_metadata!
+end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -4,4 +4,6 @@ VCR.configure do |c|
   c.cassette_library_dir = 'spec/cassettes'
   c.hook_into :webmock
   c.configure_rspec_metadata!
+  c.filter_sensitive_data('<AMAZON_ACCESS_KEY>') { ENV['AMAZON_ACCESS_KEY'] }
+  c.filter_sensitive_data('<AMAZON_SECRET_KEY>') { ENV['AMAZON_SECRET_KEY'] }
 end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -4,6 +4,6 @@ VCR.configure do |c|
   c.cassette_library_dir = 'spec/cassettes'
   c.hook_into :webmock
   c.configure_rspec_metadata!
-  c.filter_sensitive_data('<AMAZON_ACCESS_KEY>') { ENV['AMAZON_ACCESS_KEY'] }
-  c.filter_sensitive_data('<AMAZON_SECRET_KEY>') { ENV['AMAZON_SECRET_KEY'] }
+  c.filter_sensitive_data('<QUIET_AWS_ACCESS_KEY>') { ENV['QUIET_AWS_ACCESS_KEY'] }
+  c.filter_sensitive_data('<QUIET_AWS_ACCESS_KEY>') { ENV['QUIET_AWS_ACCESS_KEY'] }
 end


### PR DESCRIPTION
**Must have:**

- [x] Send shipments document to Quiet Logistics
- [x] Read shipments results document from Quiet Logistics (update tracking number/mark as shipped)
- [x] Add a pushed attribute to shipment (or an equivalent)
- [x] Either add a carrier and service level to shipping method or document it needs to be provided by `shipment#service_level` and `shipment#carrier`

**Nice to have:**

- [ ] A column of type hstore/jsonb to store the carton details